### PR TITLE
#40: Isolate gen sourceSet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # ANTLR
 *.tokens
-src/main/gen/
+src/gen/
 
 # IntelliJ IDEA
 *.iml

--- a/build.gradle
+++ b/build.gradle
@@ -1,28 +1,36 @@
 apply plugin: 'java'
 
+// Add ANTLR output as sourceSet
 sourceSets {
-    main {
+    gen {
         java {
-            srcDirs += file('src/main/gen')
+            srcDir file('src/gen/java')
         }
     }
 }
 
+// Ensure ANTLR output is generated before compilation
+compileGenJava.dependsOn 'generateGrammarSource'
+
+// Generate ANTLR output based on Swift grammar
 apply plugin: 'antlr'
 
 generateGrammarSource {
     arguments += ['-package', 'com.sleekbyte.tailor.antlr']
-    outputDirectory = file('src/main/gen/com/sleekbyte/tailor/antlr')
+    outputDirectory = file('src/gen/java/com/sleekbyte/tailor/antlr')
 }
 
+// Ensure ANTLR output is deleted via clean
 clean {
-    delete file('src/main/gen')
+    delete file('src/gen')
 }
 
+// Add run task
 apply plugin: 'application'
 
 mainClassName = 'com.sleekbyte.tailor.Tailor'
 
+// Allow arguments: `gradle run -Pargs="args"`
 run {
     if(project.hasProperty('args')){
         args project.args.split('\\s+')
@@ -35,6 +43,9 @@ repositories {
 
 dependencies {
     antlr 'org.antlr:antlr4:4.5'
+    genCompile 'org.antlr:antlr4-runtime:4.5'
+    // Ensure ANTLR output is compiled before main sourceSet
+    compile sourceSets.gen.output
     compile 'commons-cli:commons-cli:1.3.1'
     compile 'org.antlr:antlr4-runtime:4.5'
     testCompile 'junit:junit:4.12'

--- a/script/cibuild
+++ b/script/cibuild
@@ -4,5 +4,8 @@
 
 set -e
 
-# Run all tests and checks via Gradle
+# Assemble all the archives in the project
+./gradlew assemble
+
+# Perform all verification tasks in the project
 ./gradlew check

--- a/script/test
+++ b/script/test
@@ -1,8 +1,8 @@
 #!/usr/bin/env sh
 # Usage: script/test
-# Runs test suite and other checks.
+# Runs the test suite.
 
 set -e
 
-# Run tests via Gradle
+# Run the unit tests
 ./gradlew test


### PR DESCRIPTION
Provides improvements towards completing #40 by isolating ANTLR output to a separate sourceSet, depended upon by the main sourceSet.
