### PR TITLE
#111: Helper singleton

### DIFF
--- a/src/main/java/com/sleekbyte/tailor/listeners/ConstantDecListener.java
+++ b/src/main/java/com/sleekbyte/tailor/listeners/ConstantDecListener.java
@@ -14,13 +14,13 @@ import org.antlr.v4.runtime.ParserRuleContext;
  */
 public class ConstantDecListener extends SwiftBaseListener {
 
-    private ListenerHelper helper;
+    private ParseTreeVerifier verifier;
 
     /**
-     * Creates a ConstantDecListener object and retrieves the listener helper singleton.
+     * Creates a ConstantDecListener object and retrieves the listener verifier singleton.
      */
     ConstantDecListener() {
-        this.helper = ListenerHelper.INSTANCE;
+        this.verifier = ParseTreeVerifier.INSTANCE;
     }
 
     @Override
@@ -31,18 +31,18 @@ public class ConstantDecListener extends SwiftBaseListener {
 
         if (isGlobal(constantDecContext) || insideClass(constantDecContext) || insideStruct(constantDecContext)) {
             if (!CharFormatUtil.isUpperCamelCase(constantName) && !CharFormatUtil.isLowerCamelCase(constantName)) {
-                helper.printer.error(Messages.GLOBAL + Messages.CONSTANT + Messages.GLOBAL_CONSTANT_NAMING, location);
+                verifier.printer.error(Messages.GLOBAL + Messages.CONSTANT + Messages.GLOBAL_CONSTANT_NAMING, location);
             } else if (CharFormatUtil.isKPrefixed(constantName)) {
-                helper.printer.warn(Messages.CONSTANT + Messages.NAME + Messages.K_PREFIXED, location);
+                verifier.printer.warn(Messages.CONSTANT + Messages.NAME + Messages.K_PREFIXED, location);
             }
         } else {
             if (!CharFormatUtil.isLowerCamelCase(constantName)) {
-                helper.printer.error(Messages.CONSTANT + Messages.LOWER_CAMEL_CASE, location);
+                verifier.printer.error(Messages.CONSTANT + Messages.LOWER_CAMEL_CASE, location);
             } else if (CharFormatUtil.isKPrefixed(constantName)) {
-                helper.printer.warn(Messages.CONSTANT + Messages.NAME + Messages.K_PREFIXED, location);
+                verifier.printer.warn(Messages.CONSTANT + Messages.NAME + Messages.K_PREFIXED, location);
             }
         }
-        helper.verifyNameLength(Messages.CONSTANT + Messages.NAME, helper.maxLengths.maxNameLength, ctx);
+        verifier.verifyNameLength(Messages.CONSTANT + Messages.NAME, verifier.maxLengths.maxNameLength, ctx);
     }
 
     private ParserRuleContext getConstantDeclaration(ParserRuleContext ctx) {

--- a/src/main/java/com/sleekbyte/tailor/listeners/MainListener.java
+++ b/src/main/java/com/sleekbyte/tailor/listeners/MainListener.java
@@ -15,154 +15,154 @@ public class MainListener extends SwiftBaseListener {
 
     private static final String LET = "let";
     private static final String VAR = "var";
-    private ListenerHelper helper;
+    private ParseTreeVerifier verifier;
 
     /**
-     * Creates a MainListener object and a new listener helper.
+     * Creates a MainListener object and a new parse tree verifier.
      *
      * @param printer    {@link Printer} used for outputting messages to user
      * @param maxLengths {@link MaxLengths} stores numbers for max length restrictions
      */
     public MainListener(Printer printer, MaxLengths maxLengths) {
-        this.helper = ListenerHelper.INSTANCE;
-        helper.reset();
-        helper.printer = printer;
-        helper.maxLengths = maxLengths;
+        this.verifier = ParseTreeVerifier.INSTANCE;
+        verifier.reset();
+        verifier.printer = printer;
+        verifier.maxLengths = maxLengths;
     }
 
     @Override
     public void enterClassName(SwiftParser.ClassNameContext ctx) {
-        helper.verifyUpperCamelCase(Messages.CLASS + Messages.NAMES, ctx);
-        helper.verifyNameLength(Messages.CLASS + Messages.NAME, helper.maxLengths.maxNameLength, ctx);
+        verifier.verifyUpperCamelCase(Messages.CLASS + Messages.NAMES, ctx);
+        verifier.verifyNameLength(Messages.CLASS + Messages.NAME, verifier.maxLengths.maxNameLength, ctx);
     }
 
     @Override
     public void enterEnumName(SwiftParser.EnumNameContext ctx) {
-        helper.verifyUpperCamelCase(Messages.ENUM + Messages.NAMES, ctx);
-        helper.verifyNameLength(Messages.ENUM + Messages.NAME, helper.maxLengths.maxNameLength, ctx);
+        verifier.verifyUpperCamelCase(Messages.ENUM + Messages.NAMES, ctx);
+        verifier.verifyNameLength(Messages.ENUM + Messages.NAME, verifier.maxLengths.maxNameLength, ctx);
     }
 
     @Override
     public void enterEnumCaseName(SwiftParser.EnumCaseNameContext ctx) {
-        helper.verifyUpperCamelCase(Messages.ENUM_CASE + Messages.NAMES, ctx);
-        helper.verifyNameLength(Messages.ENUM_CASE + Messages.NAME, helper.maxLengths.maxNameLength, ctx);
+        verifier.verifyUpperCamelCase(Messages.ENUM_CASE + Messages.NAMES, ctx);
+        verifier.verifyNameLength(Messages.ENUM_CASE + Messages.NAME, verifier.maxLengths.maxNameLength, ctx);
     }
 
     @Override
     public void enterStructName(SwiftParser.StructNameContext ctx) {
-        helper.verifyUpperCamelCase(Messages.STRUCT + Messages.NAMES, ctx);
-        helper.verifyNameLength(Messages.STRUCT + Messages.NAME, helper.maxLengths.maxNameLength, ctx);
+        verifier.verifyUpperCamelCase(Messages.STRUCT + Messages.NAMES, ctx);
+        verifier.verifyNameLength(Messages.STRUCT + Messages.NAME, verifier.maxLengths.maxNameLength, ctx);
     }
 
     @Override
     public void enterProtocolName(SwiftParser.ProtocolNameContext ctx) {
-        helper.verifyUpperCamelCase(Messages.PROTOCOL + Messages.NAMES, ctx);
-        helper.verifyNameLength(Messages.PROTOCOL + Messages.NAME, helper.maxLengths.maxNameLength, ctx);
+        verifier.verifyUpperCamelCase(Messages.PROTOCOL + Messages.NAMES, ctx);
+        verifier.verifyNameLength(Messages.PROTOCOL + Messages.NAME, verifier.maxLengths.maxNameLength, ctx);
     }
 
     @Override
     public void enterStatement(SwiftParser.StatementContext ctx) {
-        helper.verifyNotSemicolonTerminated(Messages.STATEMENTS, ctx);
+        verifier.verifyNotSemicolonTerminated(Messages.STATEMENTS, ctx);
     }
 
     @Override
     public void enterDeclaration(SwiftParser.DeclarationContext ctx) {
-        helper.verifyNotSemicolonTerminated(Messages.STATEMENTS, ctx);
+        verifier.verifyNotSemicolonTerminated(Messages.STATEMENTS, ctx);
     }
 
     @Override
     public void enterLoopStatement(SwiftParser.LoopStatementContext ctx) {
-        helper.verifyNotSemicolonTerminated(Messages.STATEMENTS, ctx);
+        verifier.verifyNotSemicolonTerminated(Messages.STATEMENTS, ctx);
     }
 
     @Override
     public void enterBranchStatement(SwiftParser.BranchStatementContext ctx) {
-        helper.verifyNotSemicolonTerminated(Messages.STATEMENTS, ctx);
+        verifier.verifyNotSemicolonTerminated(Messages.STATEMENTS, ctx);
     }
 
     @Override
     public void enterLabeledStatement(SwiftParser.LabeledStatementContext ctx) {
-        helper.verifyNotSemicolonTerminated(Messages.STATEMENTS, ctx);
+        verifier.verifyNotSemicolonTerminated(Messages.STATEMENTS, ctx);
     }
 
     @Override
     public void enterControlTransferStatement(SwiftParser.ControlTransferStatementContext ctx) {
-        helper.verifyNotSemicolonTerminated(Messages.STATEMENTS, ctx);
+        verifier.verifyNotSemicolonTerminated(Messages.STATEMENTS, ctx);
     }
 
     @Override
     public void enterUnionStyleEnumMember(SwiftParser.UnionStyleEnumMemberContext ctx) {
-        helper.verifyNotSemicolonTerminated(Messages.STATEMENTS, ctx);
+        verifier.verifyNotSemicolonTerminated(Messages.STATEMENTS, ctx);
     }
 
     @Override
     public void enterProtocolMemberDeclaration(SwiftParser.ProtocolMemberDeclarationContext ctx) {
-        helper.verifyNotSemicolonTerminated(Messages.STATEMENTS, ctx);
+        verifier.verifyNotSemicolonTerminated(Messages.STATEMENTS, ctx);
     }
 
     @Override
     public void enterClassBody(SwiftParser.ClassBodyContext ctx) {
-        helper.verifyConstructLength(Messages.CLASS, helper.maxLengths.maxClassLength, ctx);
-        helper.verifyClassOpenBraceStyle(ctx);
+        verifier.verifyConstructLength(Messages.CLASS, verifier.maxLengths.maxClassLength, ctx);
+        verifier.verifyClassOpenBraceStyle(ctx);
     }
 
     @Override
     public void enterClosureExpression(SwiftParser.ClosureExpressionContext ctx) {
-        helper.verifyConstructLength(Messages.CLOSURE, helper.maxLengths.maxClosureLength, ctx);
-        helper.verifyClosureExpressionOpenBraceStyle(ctx);
+        verifier.verifyConstructLength(Messages.CLOSURE, verifier.maxLengths.maxClosureLength, ctx);
+        verifier.verifyClosureExpressionOpenBraceStyle(ctx);
     }
 
     @Override
     public void enterFunctionBody(SwiftParser.FunctionBodyContext ctx) {
-        helper.verifyConstructLength(Messages.FUNCTION, helper.maxLengths.maxFunctionLength, ctx);
+        verifier.verifyConstructLength(Messages.FUNCTION, verifier.maxLengths.maxFunctionLength, ctx);
     }
 
     @Override
     public void enterStructBody(SwiftParser.StructBodyContext ctx) {
-        helper.verifyConstructLength(Messages.STRUCT, helper.maxLengths.maxStructLength, ctx);
-        helper.verifyStructOpenBraceStyle(ctx);
+        verifier.verifyConstructLength(Messages.STRUCT, verifier.maxLengths.maxStructLength, ctx);
+        verifier.verifyStructOpenBraceStyle(ctx);
     }
 
     @Override
     public void enterElementName(SwiftParser.ElementNameContext ctx) {
-        helper.verifyNameLength(Messages.ELEMENT + Messages.NAME, helper.maxLengths.maxNameLength, ctx);
+        verifier.verifyNameLength(Messages.ELEMENT + Messages.NAME, verifier.maxLengths.maxNameLength, ctx);
     }
 
     @Override
     public void enterFunctionName(SwiftParser.FunctionNameContext ctx) {
-        helper.verifyNameLength(Messages.FUNCTION + Messages.NAME, helper.maxLengths.maxNameLength, ctx);
-        helper.verifyLowerCamelCase(Messages.FUNCTION + Messages.NAMES, ctx);
+        verifier.verifyNameLength(Messages.FUNCTION + Messages.NAME, verifier.maxLengths.maxNameLength, ctx);
+        verifier.verifyLowerCamelCase(Messages.FUNCTION + Messages.NAMES, ctx);
     }
 
     @Override
     public void enterLabelName(SwiftParser.LabelNameContext ctx) {
-        helper.verifyNameLength(Messages.LABEL + Messages.NAME, helper.maxLengths.maxNameLength, ctx);
+        verifier.verifyNameLength(Messages.LABEL + Messages.NAME, verifier.maxLengths.maxNameLength, ctx);
     }
 
     @Override
     public void enterSetterName(SwiftParser.SetterNameContext ctx) {
-        helper.verifyNameLength(Messages.SETTER + Messages.NAME, helper.maxLengths.maxNameLength, ctx.identifier());
+        verifier.verifyNameLength(Messages.SETTER + Messages.NAME, verifier.maxLengths.maxNameLength, ctx.identifier());
     }
 
     @Override
     public void enterTypeName(SwiftParser.TypeNameContext ctx) {
-        helper.verifyNameLength(Messages.TYPE + Messages.NAME, helper.maxLengths.maxNameLength, ctx);
+        verifier.verifyNameLength(Messages.TYPE + Messages.NAME, verifier.maxLengths.maxNameLength, ctx);
     }
 
     @Override
     public void enterTypealiasName(SwiftParser.TypealiasNameContext ctx) {
-        helper.verifyNameLength(Messages.TYPEALIAS + Messages.NAME, helper.maxLengths.maxNameLength, ctx);
+        verifier.verifyNameLength(Messages.TYPEALIAS + Messages.NAME, verifier.maxLengths.maxNameLength, ctx);
     }
 
     @Override
     public void enterVariableName(SwiftParser.VariableNameContext ctx) {
-        helper.verifyNameLength(Messages.VARIABLE + Messages.NAME, helper.maxLengths.maxNameLength, ctx);
-        helper.verifyLowerCamelCase(Messages.VARIABLE + Messages.NAMES, ctx);
+        verifier.verifyNameLength(Messages.VARIABLE + Messages.NAME, verifier.maxLengths.maxNameLength, ctx);
+        verifier.verifyLowerCamelCase(Messages.VARIABLE + Messages.NAMES, ctx);
     }
 
     @Override
     public void enterConstantDeclaration(SwiftParser.ConstantDeclarationContext ctx) {
-        helper.evaluatePatternInitializerList(ctx.patternInitializerList(), new ConstantDecListener());
+        verifier.evaluatePatternInitializerList(ctx.patternInitializerList(), new ConstantDecListener());
     }
 
     @Override
@@ -170,16 +170,16 @@ public class MainListener extends SwiftBaseListener {
         if (ctx.patternInitializerList() == null) {
             return;
         }
-        helper.evaluatePatternInitializerList(ctx.patternInitializerList(), new VariableDecListener());
+        verifier.evaluatePatternInitializerList(ctx.patternInitializerList(), new VariableDecListener());
     }
 
     @Override
     public void enterValueBindingPattern(SwiftParser.ValueBindingPatternContext ctx) {
         ParseTreeWalker walker = new ParseTreeWalker();
         if (ctx.getStart().getText().equals(LET)) {
-            helper.evaluatePattern(ctx.pattern(), walker, new ConstantDecListener());
+            verifier.evaluatePattern(ctx.pattern(), walker, new ConstantDecListener());
         } else if (ctx.getStart().getText().equals(VAR)) {
-            helper.evaluatePattern(ctx.pattern(), walker, new VariableDecListener());
+            verifier.evaluatePattern(ctx.pattern(), walker, new VariableDecListener());
         }
     }
 
@@ -195,23 +195,23 @@ public class MainListener extends SwiftBaseListener {
             The code below iterates through each declared variable and applies rules based on the last seen binding,
             'let' or 'var'.
          */
-        String currentBinding = helper.letOrVar(ctx.optionalBindingHead());
+        String currentBinding = verifier.letOrVar(ctx.optionalBindingHead());
         if (currentBinding.equals(LET)) {
-            helper.evaluateOptionalBindingHead(ctx.optionalBindingHead(), new ConstantDecListener());
+            verifier.evaluateOptionalBindingHead(ctx.optionalBindingHead(), new ConstantDecListener());
         } else if (currentBinding.equals(VAR)) {
-            helper.evaluateOptionalBindingHead(ctx.optionalBindingHead(), new VariableDecListener());
+            verifier.evaluateOptionalBindingHead(ctx.optionalBindingHead(), new VariableDecListener());
         }
         SwiftParser.OptionalBindingContinuationListContext continuationList = ctx.optionalBindingContinuationList();
         if (continuationList != null) {
             for (SwiftParser.OptionalBindingContinuationContext continuation :
                     continuationList.optionalBindingContinuation()) {
                 if (continuation.optionalBindingHead() != null) {
-                    currentBinding = helper.letOrVar(continuation.optionalBindingHead());
+                    currentBinding = verifier.letOrVar(continuation.optionalBindingHead());
                 }
                 if (currentBinding.equals(LET)) {
-                    helper.evaluateOptionalBindingContinuation(continuation, new ConstantDecListener());
+                    verifier.evaluateOptionalBindingContinuation(continuation, new ConstantDecListener());
                 } else if (currentBinding.equals(VAR)) {
-                    helper.evaluateOptionalBindingContinuation(continuation, new VariableDecListener());
+                    verifier.evaluateOptionalBindingContinuation(continuation, new VariableDecListener());
                 }
             }
         }
@@ -231,163 +231,163 @@ public class MainListener extends SwiftBaseListener {
         }
         ParseTreeWalker walker = new ParseTreeWalker();
         if (ctx.externalParameterName() != null) {
-            helper.walkListener(walker, ctx.externalParameterName(), listener);
+            verifier.walkListener(walker, ctx.externalParameterName(), listener);
         }
-        helper.walkListener(walker, ctx.localParameterName(), listener);
+        verifier.walkListener(walker, ctx.localParameterName(), listener);
     }
 
     @Override
     public void enterConditionClause(SwiftParser.ConditionClauseContext ctx) {
-        helper.verifyRedundantExpressionParenthesis(Messages.CONDITIONAL_CLAUSE, ctx.expression());
+        verifier.verifyRedundantExpressionParenthesis(Messages.CONDITIONAL_CLAUSE, ctx.expression());
     }
 
     @Override
     public void enterSwitchStatement(SwiftParser.SwitchStatementContext ctx) {
-        helper.verifyRedundantExpressionParenthesis(Messages.SWITCH_EXPRESSION, ctx.expression());
-        helper.verifySwitchStatementOpenBraceStyle(ctx);
+        verifier.verifyRedundantExpressionParenthesis(Messages.SWITCH_EXPRESSION, ctx.expression());
+        verifier.verifySwitchStatementOpenBraceStyle(ctx);
     }
 
     @Override
     public void enterForStatement(SwiftParser.ForStatementContext ctx) {
-        helper.verifyRedundantForLoopParenthesis(ctx);
-        helper.verifyForLoopOpenBraceStyle(ctx);
+        verifier.verifyRedundantForLoopParenthesis(ctx);
+        verifier.verifyForLoopOpenBraceStyle(ctx);
     }
 
     @Override
     public void enterThrowStatement(SwiftParser.ThrowStatementContext ctx) {
-        helper.verifyRedundantExpressionParenthesis(Messages.THROW_STATEMENT, ctx.expression());
+        verifier.verifyRedundantExpressionParenthesis(Messages.THROW_STATEMENT, ctx.expression());
     }
 
     @Override
     public void enterCatchClause(SwiftParser.CatchClauseContext ctx) {
-        helper.verifyRedundantCatchParentheses(ctx.pattern());
+        verifier.verifyRedundantCatchParentheses(ctx.pattern());
     }
 
     @Override
     public void enterInitializer(SwiftParser.InitializerContext ctx) {
-        helper.verifyRedundantExpressionParenthesis(Messages.INITIALIZER_EXPRESSION, ctx.expression());
+        verifier.verifyRedundantExpressionParenthesis(Messages.INITIALIZER_EXPRESSION, ctx.expression());
     }
 
     @Override
     public void enterArrayLiteralItem(SwiftParser.ArrayLiteralItemContext ctx) {
-        helper.verifyRedundantExpressionParenthesis(Messages.ARRAY_LITERAL, ctx.expression());
+        verifier.verifyRedundantExpressionParenthesis(Messages.ARRAY_LITERAL, ctx.expression());
     }
 
     @Override
     public void enterDictionaryLiteralItem(SwiftParser.DictionaryLiteralItemContext ctx) {
         for (SwiftParser.ExpressionContext expressionContext : ctx.expression()) {
-            helper.verifyRedundantExpressionParenthesis(Messages.DICTIONARY_LITERAL, expressionContext);
+            verifier.verifyRedundantExpressionParenthesis(Messages.DICTIONARY_LITERAL, expressionContext);
         }
-        helper.checkWhitespaceAroundColon(ctx);
+        verifier.checkWhitespaceAroundColon(ctx);
     }
 
     @Override
     public void enterImportDeclaration(SwiftParser.ImportDeclarationContext ctx) {
-        helper.verifyMultipleImports(ctx);
+        verifier.verifyMultipleImports(ctx);
     }
 
     @Override
     public void enterFunctionDeclaration(SwiftParser.FunctionDeclarationContext ctx) {
-        helper.verifyFunctionOpenBraceStyle(ctx);
+        verifier.verifyFunctionOpenBraceStyle(ctx);
     }
 
     @Override
     public void enterElseClause(SwiftParser.ElseClauseContext ctx) {
-        helper.verifyElseClauseOpenBraceStyle(ctx);
+        verifier.verifyElseClauseOpenBraceStyle(ctx);
     }
 
     @Override
     public void enterIfStatement(SwiftParser.IfStatementContext ctx) {
-        helper.verifyIfStatementOpenBraceStyle(ctx);
+        verifier.verifyIfStatementOpenBraceStyle(ctx);
     }
 
     @Override
     public void enterWhileStatement(SwiftParser.WhileStatementContext ctx) {
-        helper.verifyWhileLoopOpenBraceStyle(ctx);
+        verifier.verifyWhileLoopOpenBraceStyle(ctx);
     }
 
     @Override
     public void enterRepeatWhileStatement(SwiftParser.RepeatWhileStatementContext ctx) {
-        helper.verifyRepeatWhileLoopOpenBraceStyle(ctx);
+        verifier.verifyRepeatWhileLoopOpenBraceStyle(ctx);
     }
 
     @Override
     public void enterInitializerDeclaration(SwiftParser.InitializerDeclarationContext ctx) {
-        helper.verifyInitializerOpenBraceStyle(ctx);
+        verifier.verifyInitializerOpenBraceStyle(ctx);
     }
 
     @Override
     public void enterForInStatement(SwiftParser.ForInStatementContext ctx) {
-        helper.verifyForInStatementOpenBraceStyle(ctx);
+        verifier.verifyForInStatementOpenBraceStyle(ctx);
     }
 
     @Override
     public void enterOperatorDeclaration(SwiftParser.OperatorDeclarationContext ctx) {
-        helper.checkWhitespaceAroundOperator(ctx);
+        verifier.checkWhitespaceAroundOperator(ctx);
     }
 
     @Override
     public void enterTypeAnnotation(SwiftParser.TypeAnnotationContext ctx) {
-        helper.checkWhitespaceAroundColon(ctx);
+        verifier.checkWhitespaceAroundColon(ctx);
     }
 
     @Override
     public void enterProtocolBody(SwiftParser.ProtocolBodyContext ctx) {
-        helper.verifyProtocolOpenBraceStyle(ctx);
+        verifier.verifyProtocolOpenBraceStyle(ctx);
     }
 
     @Override
     public void enterUnionStyleEnum(SwiftParser.UnionStyleEnumContext ctx) {
-        helper.verifyEnumOpenBraceStyle(ctx);
+        verifier.verifyEnumOpenBraceStyle(ctx);
     }
 
     @Override
     public void enterRawValueStyleEnum(SwiftParser.RawValueStyleEnumContext ctx) {
-        helper.verifyEnumOpenBraceStyle(ctx);
+        verifier.verifyEnumOpenBraceStyle(ctx);
     }
 
     @Override
     public void enterDictionaryType(SwiftParser.DictionaryTypeContext ctx) {
-        helper.checkWhitespaceAroundColon(ctx);
+        verifier.checkWhitespaceAroundColon(ctx);
     }
 
     @Override
     public void enterSwitchCase(SwiftParser.SwitchCaseContext ctx) {
-        helper.checkWhitespaceAroundColon(ctx);
+        verifier.checkWhitespaceAroundColon(ctx);
     }
 
     @Override
     public void enterTypeInheritanceClause(SwiftParser.TypeInheritanceClauseContext ctx) {
-        helper.checkWhitespaceAroundColon(ctx);
+        verifier.checkWhitespaceAroundColon(ctx);
     }
 
     @Override
     public void enterConditionalOperator(SwiftParser.ConditionalOperatorContext ctx) {
-        helper.checkWhitespaceAroundColon(ctx);
+        verifier.checkWhitespaceAroundColon(ctx);
     }
 
     @Override
     public void enterExpressionElement(SwiftParser.ExpressionElementContext ctx) {
-        helper.checkWhitespaceAroundColon(ctx);
+        verifier.checkWhitespaceAroundColon(ctx);
     }
 
     @Override
     public void enterGenericParameter(SwiftParser.GenericParameterContext ctx) {
-        helper.checkWhitespaceAroundColon(ctx);
+        verifier.checkWhitespaceAroundColon(ctx);
     }
 
     @Override
     public void enterExtensionBody(SwiftParser.ExtensionBodyContext ctx) {
-        helper.verifyExtensionOpenBraceStyle(ctx);
+        verifier.verifyExtensionOpenBraceStyle(ctx);
     }
 
     @Override
     public void enterGetterClause(SwiftParser.GetterClauseContext ctx) {
-        helper.verifyGetterOpenBraceStyle(ctx);
+        verifier.verifyGetterOpenBraceStyle(ctx);
     }
 
     @Override
     public void enterSetterClause(SwiftParser.SetterClauseContext ctx) {
-        helper.verifySetterOpenBraceStyle(ctx);
+        verifier.verifySetterOpenBraceStyle(ctx);
     }
 }

--- a/src/main/java/com/sleekbyte/tailor/listeners/ParseTreeVerifier.java
+++ b/src/main/java/com/sleekbyte/tailor/listeners/ParseTreeVerifier.java
@@ -60,16 +60,16 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Helper class for {@link MainListener}.
+ * Verifier class for listeners that extend {@link SwiftBaseListener}.
  */
-class ListenerHelper {
+class ParseTreeVerifier {
 
     private Set<Integer> importLineNumbers = new HashSet<>();
     Printer printer;
     MaxLengths maxLengths;
-    static final ListenerHelper INSTANCE = new ListenerHelper();
+    static final ParseTreeVerifier INSTANCE = new ParseTreeVerifier();
 
-    private ListenerHelper() {
+    private ParseTreeVerifier() {
         // Exists only to defeat instantiation.
     }
 

--- a/src/main/java/com/sleekbyte/tailor/listeners/VariableDecListener.java
+++ b/src/main/java/com/sleekbyte/tailor/listeners/VariableDecListener.java
@@ -12,13 +12,13 @@ import com.sleekbyte.tailor.utils.ListenerUtil;
  */
 public class VariableDecListener extends SwiftBaseListener {
 
-    private ListenerHelper helper;
+    private ParseTreeVerifier verifier;
 
     /**
-     * Creates a VariableDecListener object and retrieves the listener helper singleton.
+     * Creates a VariableDecListener object and retrieves the listener verifier singleton.
      */
     VariableDecListener() {
-        this.helper = ListenerHelper.INSTANCE;
+        this.verifier = ParseTreeVerifier.INSTANCE;
     }
 
     @Override
@@ -27,8 +27,8 @@ public class VariableDecListener extends SwiftBaseListener {
         Location location = ListenerUtil.getContextStartLocation(ctx);
 
         if (!CharFormatUtil.isLowerCamelCase(variableName)) {
-            helper.printer.error(Messages.VARIABLE + Messages.NAMES + Messages.LOWER_CAMEL_CASE, location);
+            verifier.printer.error(Messages.VARIABLE + Messages.NAMES + Messages.LOWER_CAMEL_CASE, location);
         }
-        helper.verifyNameLength(Messages.VARIABLE + Messages.NAME, helper.maxLengths.maxNameLength, ctx);
+        verifier.verifyNameLength(Messages.VARIABLE + Messages.NAME, verifier.maxLengths.maxNameLength, ctx);
     }
 }


### PR DESCRIPTION
Resolves #111.

Changes:

b9500ed
   Remove unnecessary continuation line break

50b383c
   Make printer and maxLengths package-private
- Remove the need to use getters and setters for printer and maxLengths

5237301
   Enforce singleton pattern on ListenerHelper

   Use "Simply Singleton" Example 7 for a simple, fast, and thread-safe
   singleton implementation:
   http://www.javaworld.com/article/2073352/core-java/simply-singleton.html

08f452d
   Rename MainListenerHelper to ListenerHelper

67cb651
   Only use single instance of MainListenerHelper
