### PR TITLE
#117: Remove classes from dist

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ run {
 distributions {
     main {
         contents {
-            exclude('**/com/**')
+            exclude('com/')
         }
     }
 }


### PR DESCRIPTION
Exclude ANTLR output class files from distribution, resolves #117.

This ensures that `gradle [distZip|distTar|installDist]` does not contain `tailor/lib/com/sleekbyte/tailor/antlr/*.class`.

New, clean tree:

```
./bin/tailor
./bin/tailor.bat
./lib/antlr-runtime-3.5.2.jar
./lib/antlr4-4.5.jar
./lib/antlr4-runtime-4.5.jar
./lib/commons-cli-1.3.1.jar
./lib/org.abego.treelayout.core-1.0.1.jar
./lib/ST4-4.0.8.jar
./lib/tailor.jar
```
