### PR TITLE
#132: Out of bounds exception fix

### DIFF
--- a/src/main/java/com/sleekbyte/tailor/listeners/ParseTreeVerifier.java
+++ b/src/main/java/com/sleekbyte/tailor/listeners/ParseTreeVerifier.java
@@ -431,7 +431,7 @@ class ParseTreeVerifier {
 
         int closeBraceTokenIndex = closeBraceToken.getTokenIndex();
         if (closeBraceTokenIndex >= 0) {
-            List<Token> tokens = tokenStream.getHiddenTokensToLeft(closeBraceToken.getTokenIndex());
+            List<Token> tokens = tokenStream.getHiddenTokensToLeft(closeBraceTokenIndex);
             // if comments are to the left of }
             if (tokens != null) {
                 Token commentToken = getLastCommentToken(tokens);


### PR DESCRIPTION
Compute list of hidden tokens iff token index non negative.

Fixes #132.
