### PR TITLE
#132: Allow classes to be declared final

### DIFF
--- a/src/main/antlr/Swift.g4
+++ b/src/main/antlr/Swift.g4
@@ -248,13 +248,13 @@ initializer : '=' expression  ;
 // GRAMMAR OF A VARIABLE DECLARATION
 
 variableDeclaration
- : variableDeclarationHead patternInitializerList
- | variableDeclarationHead variableName typeAnnotation getterSetterBlock
+ : variableDeclarationHead variableName typeAnnotation getterSetterBlock
  | variableDeclarationHead variableName typeAnnotation getterSetterKeywordBlock
  | variableDeclarationHead variableName initializer willSetDidSetBlock
  | variableDeclarationHead variableName typeAnnotation initializer? willSetDidSetBlock
  // keep this below getter and setter rules for ambiguity reasons
  | variableDeclarationHead variableName typeAnnotation codeBlock
+ | variableDeclarationHead patternInitializerList
  ;
 
 variableDeclarationHead : attributes? declarationModifiers? 'var'  ;
@@ -326,7 +326,8 @@ structBody : '{' declarations?'}'  ;
 
 // GRAMMAR OF A CLASS DECLARATION
 
-classDeclaration : attributes? accessLevelModifier? 'class' className genericParameterClause? typeInheritanceClause? classBody  ;
+// declarationModifier missing in Swift Language Reference
+classDeclaration : attributes? declarationModifier? accessLevelModifier? 'class' className genericParameterClause? typeInheritanceClause? classBody  ;
 className : identifier ;
 classBody : '{' declarations? '}'  ;
 

--- a/src/test/swift/com/sleekbyte/tailor/grammar/ClassesAndStructures.swift
+++ b/src/test/swift/com/sleekbyte/tailor/grammar/ClassesAndStructures.swift
@@ -160,3 +160,8 @@ struct AudioChannel {
         }
     }
 }
+
+@objc final internal class World {
+  internal var exampleHooks: ExampleHooks {return configuration.exampleHooks }
+  internal var suiteHooks: SuiteHooks { return configuration.suiteHooks }
+}


### PR DESCRIPTION
Fixes #132.
- Classes can be declared final
- Variable declarations can have code blocks associated with them
