### PR TITLE
#226: Fix bug where disabled errors exit with an error

### DIFF
--- a/src/main/java/com/sleekbyte/tailor/output/Printer.java
+++ b/src/main/java/com/sleekbyte/tailor/output/Printer.java
@@ -134,7 +134,9 @@ public class Printer implements AutoCloseable {
     }
 
     private long getNumMessagesWithSeverity(Severity severity) {
-        return msgBuffer.values().stream().filter(msg -> msg.getSeverity().equals(severity)).count();
+        return msgBuffer.values().stream()
+            .filter(msg -> !ignoredLineNumbers.contains(msg.getLineNumber()))
+            .filter(msg -> msg.getSeverity().equals(severity)).count();
     }
 
     public long getNumErrorMessages() {

--- a/src/test/java/com/sleekbyte/tailor/functional/RuleTest.java
+++ b/src/test/java/com/sleekbyte/tailor/functional/RuleTest.java
@@ -1,6 +1,7 @@
 package com.sleekbyte.tailor.functional;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.sleekbyte.tailor.Tailor;
 import org.junit.After;
@@ -60,7 +61,7 @@ public abstract class RuleTest {
         List<String> actualOutput = new ArrayList<>();
 
         String[] msgs = outContent.toString(Charset.defaultCharset().name()).split(NEWLINE_REGEX);
-
+        String summary = msgs[msgs.length - 1];
         // Skip first two lines for file header, last two lines for summary
         msgs = Arrays.copyOfRange(msgs, 2, msgs.length - 2);
 
@@ -69,6 +70,8 @@ public abstract class RuleTest {
             actualOutput.add(truncatedMsg);
         }
 
+        // Ensure number of warnings in summary equals actual number of warnings in the output
+        assertTrue(summary.contains(expectedMessages.size() + " violation"));
         assertArrayEquals(outContent.toString(Charset.defaultCharset().name()), this.expectedMessages.toArray(),
             actualOutput.toArray());
     }


### PR DESCRIPTION
Fixes #226.

**Cause**: Disabled errors were filtered out *after* retrieving the stats for number of warnings and errors.

**Mitigation**: Filter out disabled errors *when* retrieving the stats for number of warnings and errors.