### PR TITLE
#69: Implement redundant method parens rule

### DIFF
--- a/src/main/java/com/sleekbyte/tailor/common/Messages.java
+++ b/src/main/java/com/sleekbyte/tailor/common/Messages.java
@@ -67,6 +67,7 @@ public class Messages {
     public static final String TODOS = "TODO comments ";
     public static final String GENERIC_PARAMETERS = "Generic parameters ";
     public static final String COMMA = "Comma ";
+    public static final String EMPTY_PARENTHESES = "Empty parentheses ";
 
     // Plural constructs
     public static final String IMPORTS = "Imports ";
@@ -101,6 +102,8 @@ public class Messages {
     public static final String END_SPACE = "should end with whitespace";
     public static final String TODO_SYNTAX = "should be formatted either as <TODO: description>"
         + " or <TODO(dev-name): description>";
+    public static final String REDUNDANT_METHOD_PARENTHESES = "following method call with trailing closure argument"
+        + " should be removed";
 
     // Usage messages
     public static final String CMD_LINE_SYNTAX = "tailor [options] [--] [[file|directory] ...]";

--- a/src/test/java/com/sleekbyte/tailor/functional/ArrowWhitespaceTest.java
+++ b/src/test/java/com/sleekbyte/tailor/functional/ArrowWhitespaceTest.java
@@ -52,4 +52,9 @@ public class ArrowWhitespaceTest extends RuleTest {
             )
         );
     }
+
+    @Override
+    protected String[] getCommandArgs() {
+        return new String[] { "--only=arrow-whitespace" };
+    }
 }

--- a/src/test/java/com/sleekbyte/tailor/functional/BraceWhitespaceTest.java
+++ b/src/test/java/com/sleekbyte/tailor/functional/BraceWhitespaceTest.java
@@ -93,6 +93,6 @@ public class BraceWhitespaceTest extends RuleTest {
 
     @Override
     protected String[] getCommandArgs() {
-        return new String[] { "--only=brace-whitespace" };
+        return new String[] { "--only=brace-style" };
     }
 }

--- a/src/test/java/com/sleekbyte/tailor/functional/BraceWhitespaceTest.java
+++ b/src/test/java/com/sleekbyte/tailor/functional/BraceWhitespaceTest.java
@@ -90,4 +90,9 @@ public class BraceWhitespaceTest extends RuleTest {
             )
         );
     }
+
+    @Override
+    protected String[] getCommandArgs() {
+        return new String[] { "--only=brace-whitespace" };
+    }
 }

--- a/src/test/java/com/sleekbyte/tailor/functional/RedundantParenthesesTest.java
+++ b/src/test/java/com/sleekbyte/tailor/functional/RedundantParenthesesTest.java
@@ -33,6 +33,8 @@ public class RedundantParenthesesTest extends RuleTest {
         addExpectedMsg(66, 18, Severity.WARNING, Messages.INITIALIZER_EXPRESSION + Messages.ENCLOSED_PARENTHESES);
         addExpectedMsg(67, 21, Severity.WARNING, Messages.INITIALIZER_EXPRESSION + Messages.ENCLOSED_PARENTHESES);
         addExpectedMsg(68, 13, Severity.WARNING, Messages.INITIALIZER_EXPRESSION + Messages.ENCLOSED_PARENTHESES);
+        addExpectedMsg(78, 10, Severity.WARNING, Messages.EMPTY_PARENTHESES + Messages.REDUNDANT_METHOD_PARENTHESES);
+        addExpectedMsg(92, 15, Severity.WARNING, Messages.EMPTY_PARENTHESES + Messages.REDUNDANT_METHOD_PARENTHESES);
     }
 
     private void addExpectedMsg(int line, int column, Severity classification, String msg) {

--- a/src/test/swift/com/sleekbyte/tailor/functional/RedundantParenthesesTest.swift
+++ b/src/test/swift/com/sleekbyte/tailor/functional/RedundantParenthesesTest.swift
@@ -70,3 +70,26 @@ func demo() {
     var airports = [ (1, 2) , (3, 4) ]
     var airports: [String: (String, String)] = [ "YYZ": ("Toronto", "Toronto Pearson") ]
 }
+
+items.map {
+  (item) in item.transform()
+}
+
+items.map() {
+  (item) in item.transform()
+}
+
+items.mapWithParams(params) {
+  (item) in item.transform()
+}
+
+items.map({
+  (item) in item.transform()
+})
+
+matrix.map {
+  (vector) in
+    vector.map() {
+      (el) in el * el
+    }
+}


### PR DESCRIPTION
Resolves #69. 

The rule is added under the `redundant-parentheses` rule.