### PR TITLE
#276: Fix some grammar bugs

### DIFF
--- a/src/main/antlr/com/sleekbyte/tailor/antlr/Swift.g4
+++ b/src/main/antlr/com/sleekbyte/tailor/antlr/Swift.g4
@@ -75,7 +75,7 @@ forInit : variableDeclaration | expressionList  ;
 
 // GRAMMAR OF A FOR_IN STATEMENT
 
-forInStatement : 'for' 'case'? pattern 'in' expression codeBlock whereClause? ;
+forInStatement : 'for' 'case'? pattern 'in' expression whereClause? codeBlock  ;
 
 // GRAMMAR OF A WHILE STATEMENT
 
@@ -308,6 +308,7 @@ parameterList : parameter | parameter ',' parameterList  ;
 parameter : attributes? 'inout'? 'let'? '#'? externalParameterName? localParameterName typeAnnotation? defaultArgumentClause?
  | 'inout'? 'var' '#'? externalParameterName? localParameterName typeAnnotation? defaultArgumentClause?
  | attributes? sType
+ | externalParameterName? localParameterName typeAnnotation '...'
  ;
 externalParameterName : identifier | '_'  ;
 localParameterName : identifier | '_'  ;
@@ -848,7 +849,7 @@ NilLiteral: 'nil' ;
 
 identifier : Identifier | contextSensitiveKeyword ;
 
-keyword : 'convenience' | 'class' | 'deinit' | 'enum' | 'extension' | 'func' | 'import' | 'init' | 'let' | 'protocol' | 'static' | 'struct' | 'subscript' | 'typealias' | 'var' | 'break' | 'case' | 'continue' | 'default' | 'do' | 'else' | 'fallthrough' | 'if' | 'in' | 'for' | 'return' | 'switch' | 'where' | 'while' | 'as' | 'dynamicType' | 'is' | 'new' | 'super' | 'self' | 'Self' | 'Type' | 'repeat' ;
+keyword : 'convenience' | 'class' | 'deinit' | 'enum' | 'extension' | 'func' | 'import' | 'init' | 'let' | 'protocol' | 'static' | 'struct' | 'subscript' | 'typealias' | 'var' | 'break' | 'case' | 'continue' | 'default' | 'do' | 'else' | 'fallthrough' | 'if' | 'in' | 'for' | 'return' | 'switch' | 'where' | 'while' | 'as' | 'dynamicType' | 'is' | 'super' | 'self' | 'Self' | 'Type' | 'repeat' ;
 
 contextSensitiveKeyword :
  'associativity' | 'convenience' | 'dynamic' | 'didSet' | 'final' | 'get' | 'infix' | 'indirect' |

--- a/src/main/java/com/sleekbyte/tailor/listeners/BraceStyleListener.java
+++ b/src/main/java/com/sleekbyte/tailor/listeners/BraceStyleListener.java
@@ -160,7 +160,8 @@ public class BraceStyleListener extends SwiftBaseListener {
     }
 
     private void verifyForInStatementBraceStyle(SwiftParser.ForInStatementContext ctx) {
-        verifyCodeBlockOpenBraceStyle(ctx.codeBlock(), ctx.expression().getStop(), Messages.FOR_IN_LOOP);
+        Token leftOfCodeBlock = ctx.whereClause() == null ? ctx.expression().getStop() : ctx.whereClause().getStop();
+        verifyCodeBlockOpenBraceStyle(ctx.codeBlock(), leftOfCodeBlock, Messages.FOR_IN_LOOP);
         verifyBodyCloseBraceStyle(ctx.codeBlock(), Messages.FOR_IN_LOOP);
     }
 

--- a/src/test/java/com/sleekbyte/tailor/functional/BraceWhitespaceTest.java
+++ b/src/test/java/com/sleekbyte/tailor/functional/BraceWhitespaceTest.java
@@ -36,20 +36,21 @@ public class BraceWhitespaceTest extends RuleTest {
         addExpectedMsg(start + 54, 22);
         addExpectedMsg(start + 70, 20);
         addExpectedMsg(start + 75, 18);
+        addExpectedMsg(start + 79, 71);
 
         // classes and structs with generic types
-        start = 122;
+        start = 126;
         addExpectedMsg(start, 6);
         addExpectedMsg(start + 3, 4);
 
         // protocols
-        start = 131;
+        start = 135;
         addExpectedMsg(start, 24);
         addExpectedMsg(start + 4, 32);
         addExpectedMsg(start + 13, 24);
 
         // enums
-        start = 158;
+        start = 162;
         addExpectedMsg(start, 16);
         addExpectedMsg(start + 4, 27);
         addExpectedMsg(start + 17, 6);
@@ -57,19 +58,19 @@ public class BraceWhitespaceTest extends RuleTest {
         addExpectedMsg(start + 34, 19);
 
         // closures
-        start = 196;
+        start = 200;
         addExpectedMsg(start, 29);
         addExpectedMsg(start + 14, 72);
         addExpectedMsg(start + 18, 17);
 
         // extensions
-        start = 232;
+        start = 236;
         addExpectedMsg(start, 26);
         addExpectedMsg(start + 4, 29);
         addExpectedMsg(start + 9, 19);
 
         // getters and setters
-        start = 246;
+        start = 250;
         addExpectedMsg(start, 8);
         addExpectedMsg(start + 4, 8);
         addExpectedMsg(start + 21, 14);

--- a/src/test/swift/com/sleekbyte/tailor/functional/BraceWhitespaceTest.swift
+++ b/src/test/swift/com/sleekbyte/tailor/functional/BraceWhitespaceTest.swift
@@ -110,6 +110,10 @@ class Rectangle: Shape {
                 x{
 
             }
+
+            for pkg in parms.dependencies where pkg.type == .ModuleMap{
+                println(pkg.name)
+            }
         }
 
    }

--- a/src/test/swift/com/sleekbyte/tailor/grammar/ControlFlow.swift
+++ b/src/test/swift/com/sleekbyte/tailor/grammar/ControlFlow.swift
@@ -215,3 +215,8 @@ for var i = 0; i < Int(width); i++, sp = sp.advancedBy(4), dp = dp.advancedBy(4)
         memcpy(dp, sp, 4)
     }
 }
+
+for pkg in parms.dependencies where pkg.type == .ModuleMap {
+    let path = Path.join(pkg.path, "module.modulemap")
+    args += ["-Xcc", "-F-module-map=\(path)", "-I", pkg.path]
+}

--- a/src/test/swift/com/sleekbyte/tailor/grammar/Enumerations.swift
+++ b/src/test/swift/com/sleekbyte/tailor/grammar/Enumerations.swift
@@ -135,3 +135,30 @@ internal indirect enum Either<L, R> {
 	case Left(L)
 	case Right(R)
 }
+
+public enum SystemError: ErrorType {
+    case chdir(Int32)
+    case close(Int32)
+    case dirfd(Int32, String)
+    case fopen(Int32, String)
+    case fputs
+    case fgetc(Int32)
+    case fread(Int32)
+    case getcwd(Int32)
+    case mkdir(Int32, String)
+    case mkdtemp(Int32)
+    case opendir(Int32, String)
+    case pipe(Int32)
+    case popen(Int32, String)
+    case posix_spawn(Int32, [String])
+    case read(Int32)
+    case readdir(Int32, String)
+    case readlink(Int32, String)
+    case realpath(Int32, String)
+    case rename(Int32, old: String, new: String)
+    case rmdir(Int32, String)
+    case stat(Int32, String)
+    case symlinkat(Int32, String)
+    case unlink(Int32, String)
+    case waitpid(Int32)
+}

--- a/src/test/swift/com/sleekbyte/tailor/grammar/Functions.swift
+++ b/src/test/swift/com/sleekbyte/tailor/grammar/Functions.swift
@@ -147,3 +147,10 @@ public func success(@noescape closure: T -> Void) {
 public prefix func <-<R: FallibleSendable>(channel: R) throws -> R.T? {
     return try channel.send()
 }
+
+public func fopen(path: String..., mode: String = "r") throws -> UnsafeMutablePointer<FILE> {
+    let path = joinPathComponents(path)
+    let f = libc.fopen(path, mode)
+    guard f != nil else { throw SystemError.fopen(errno, path) }
+    return f
+}


### PR DESCRIPTION
Fixes #276.

- Fix grammar issues
- Fix `BraceStyleListener` to accomodate for `where` clause in `for-in` loops