### PR TITLE
#280: Do not flag absence of whitespace between Generic and normal parameter clauses

### DIFF
--- a/src/main/java/com/sleekbyte/tailor/listeners/whitespace/ParenthesisWhitespaceListener.java
+++ b/src/main/java/com/sleekbyte/tailor/listeners/whitespace/ParenthesisWhitespaceListener.java
@@ -4,6 +4,7 @@ import com.sleekbyte.tailor.antlr.SwiftBaseListener;
 import com.sleekbyte.tailor.antlr.SwiftParser;
 import com.sleekbyte.tailor.antlr.SwiftParser.FunctionNameContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.FunctionSignatureContext;
+import com.sleekbyte.tailor.antlr.SwiftParser.GenericParameterClauseContext;
 import com.sleekbyte.tailor.common.Messages;
 import com.sleekbyte.tailor.common.Rules;
 import com.sleekbyte.tailor.output.Printer;
@@ -45,7 +46,8 @@ public final class ParenthesisWhitespaceListener extends SwiftBaseListener {
             // 2nd child is functionName
             FunctionNameContext functionName = (FunctionNameContext) declaration.getChild(1);
             // Check for operator overloaded methods
-            if (functionName.operator() != null) {
+            if (functionName.operator() != null
+                && !(declaration.getChild(2) instanceof GenericParameterClauseContext)) {
                 verifier.verifyLeadingWhitespaceBeforeBracket(ctx, Messages.OPERATOR_OVERLOADING_ONE_SPACE, 1);
                 return;
             }

--- a/src/test/java/com/sleekbyte/tailor/functional/ParenthesisWhitespaceTest.java
+++ b/src/test/java/com/sleekbyte/tailor/functional/ParenthesisWhitespaceTest.java
@@ -41,6 +41,7 @@ public final class ParenthesisWhitespaceTest extends RuleTest {
         addExpectedMessage(81, 27, Messages.PARENTHESES + Messages.CONTENT + Messages.LEADING_WHITESPACE);
         addExpectedMessage(81, 41, Messages.PARENTHESES + Messages.CONTENT + Messages.NOT_END_SPACE);
         addExpectedMessage(90, 14, Messages.OPERATOR_OVERLOADING_ONE_SPACE);
+        addExpectedMessage(113, 13, Messages.PARENTHESES + Messages.NO_WHITESPACE_BEFORE);
     }
 
     private void addExpectedMessage(int line, int column, String msg) {

--- a/src/test/swift/com/sleekbyte/tailor/functional/ParenthesisWhitespaceTest.swift
+++ b/src/test/swift/com/sleekbyte/tailor/functional/ParenthesisWhitespaceTest.swift
@@ -109,3 +109,7 @@ func ** (left: Double, right: Double) -> Double {
 }
 
 func <| (lhs: Int, rhs: Int) -> Int {}
+
+func <|< <A> (lhs: A, rhs: A) -> A
+
+func <|< <A>(lhs: A, rhs: A) -> A


### PR DESCRIPTION
Fixes #280.