### PR TITLE
#240: Comma Whitespace Checks #3

### DIFF
--- a/src/main/java/com/sleekbyte/tailor/listeners/whitespace/CommaWhitespaceListener.java
+++ b/src/main/java/com/sleekbyte/tailor/listeners/whitespace/CommaWhitespaceListener.java
@@ -4,6 +4,7 @@ import com.sleekbyte.tailor.antlr.SwiftBaseListener;
 import com.sleekbyte.tailor.antlr.SwiftParser;
 import com.sleekbyte.tailor.antlr.SwiftParser.AvailabilityArgumentsContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.ConditionClauseContext;
+import com.sleekbyte.tailor.antlr.SwiftParser.ExpressionListContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.GenericArgumentListContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.OptionalBindingConditionContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.ParameterListContext;
@@ -126,6 +127,11 @@ public final class CommaWhitespaceListener extends SwiftBaseListener {
 
     @Override
     public void enterTupleTypeElementList(TupleTypeElementListContext ctx) {
+        checkWhitespaceAroundCommaSeparatedList(ctx);
+    }
+
+    @Override
+    public void enterExpressionList(ExpressionListContext ctx) {
         checkWhitespaceAroundCommaSeparatedList(ctx);
     }
 

--- a/src/main/java/com/sleekbyte/tailor/listeners/whitespace/CommaWhitespaceListener.java
+++ b/src/main/java/com/sleekbyte/tailor/listeners/whitespace/CommaWhitespaceListener.java
@@ -5,6 +5,7 @@ import com.sleekbyte.tailor.antlr.SwiftParser;
 import com.sleekbyte.tailor.antlr.SwiftParser.ArrayLiteralItemsContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.AvailabilityArgumentsContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.ConditionClauseContext;
+import com.sleekbyte.tailor.antlr.SwiftParser.DictionaryLiteralItemsContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.ExpressionListContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.GenericArgumentListContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.OptionalBindingConditionContext;
@@ -138,6 +139,11 @@ public final class CommaWhitespaceListener extends SwiftBaseListener {
 
     @Override
     public void enterArrayLiteralItems(ArrayLiteralItemsContext ctx) {
+        checkWhitespaceAroundCommaSeparatedList(ctx);
+    }
+
+    @Override
+    public void enterDictionaryLiteralItems(DictionaryLiteralItemsContext ctx) {
         checkWhitespaceAroundCommaSeparatedList(ctx);
     }
 

--- a/src/main/java/com/sleekbyte/tailor/listeners/whitespace/CommaWhitespaceListener.java
+++ b/src/main/java/com/sleekbyte/tailor/listeners/whitespace/CommaWhitespaceListener.java
@@ -9,6 +9,8 @@ import com.sleekbyte.tailor.antlr.SwiftParser.OptionalBindingConditionContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.ParameterListContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.PatternInitializerListContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.RawValueStyleEnumCaseListContext;
+import com.sleekbyte.tailor.antlr.SwiftParser.TuplePatternElementListContext;
+import com.sleekbyte.tailor.antlr.SwiftParser.TupleTypeElementListContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.UnionStyleEnumCaseListContext;
 import com.sleekbyte.tailor.common.Messages;
 import com.sleekbyte.tailor.common.Rules;
@@ -114,6 +116,16 @@ public final class CommaWhitespaceListener extends SwiftBaseListener {
 
     @Override
     public void enterRawValueStyleEnumCaseList(RawValueStyleEnumCaseListContext ctx) {
+        checkWhitespaceAroundCommaSeparatedList(ctx);
+    }
+
+    @Override
+    public void enterTuplePatternElementList(TuplePatternElementListContext ctx) {
+        checkWhitespaceAroundCommaSeparatedList(ctx);
+    }
+
+    @Override
+    public void enterTupleTypeElementList(TupleTypeElementListContext ctx) {
         checkWhitespaceAroundCommaSeparatedList(ctx);
     }
 

--- a/src/main/java/com/sleekbyte/tailor/utils/WhitespaceVerifier.java
+++ b/src/main/java/com/sleekbyte/tailor/utils/WhitespaceVerifier.java
@@ -35,6 +35,22 @@ public final class WhitespaceVerifier {
     }
 
     /**
+     * Verifies if a certain punctuation token is left associated (no space on the left).
+     *
+     * @param left Token on the left of the punctuation token
+     * @param punc Punctuation token
+     * @param puncStr String version of the punctuation to be used in violation messages
+     */
+    public void verifyPunctuationLeftAssociation(Token left, Token punc, String puncStr) {
+        Location puncLocation = ListenerUtil.getTokenLocation(punc);
+
+        if (checkIfInline(left, punc) || checkLeftSpaces(left, punc, 0)) {
+            printer.error(rule, puncStr + Messages.AT_COLUMN + puncLocation.column + " "
+                + Messages.NO_SPACE_BEFORE, puncLocation);
+        }
+    }
+
+    /**
      * Verifies if a certain punctuation token is left associated (no space on the left, one space on the right).
      *
      * @param left Token on the left of the punctuation token
@@ -45,10 +61,7 @@ public final class WhitespaceVerifier {
     public void verifyPunctuationLeftAssociation(Token left, Token right, Token punc, String puncStr) {
         Location puncLocation = ListenerUtil.getTokenLocation(punc);
 
-        if (checkIfInline(left, punc) || checkLeftSpaces(left, punc, 0)) {
-            printer.error(rule, puncStr + Messages.AT_COLUMN + puncLocation.column + " "
-                + Messages.NO_SPACE_BEFORE, puncLocation);
-        }
+        verifyPunctuationLeftAssociation(left, punc, puncStr);
 
         if (checkRightSpaces(right, punc, 1)) {
             printer.error(rule, puncStr + Messages.AT_COLUMN + puncLocation.column + " "

--- a/src/test/java/com/sleekbyte/tailor/functional/CommaWhitespaceTest.java
+++ b/src/test/java/com/sleekbyte/tailor/functional/CommaWhitespaceTest.java
@@ -95,6 +95,12 @@ public class CommaWhitespaceTest extends RuleTest {
         addExpectedCommaMessage(start + 4, 46, Messages.NO_SPACE_BEFORE);
         addExpectedCommaMessage(start + 8, 46, Messages.NO_SPACE_BEFORE);
 
+        // Array Literals
+        start = 237;
+        addExpectedCommaMessage(start, 37, Messages.NO_SPACE_BEFORE);
+        addExpectedCommaMessage(start, 47, Messages.SPACE_AFTER);
+        addExpectedCommaMessage(start + 2, 36, Messages.SPACE_AFTER);
+        addExpectedCommaMessage(start + 6, 57, Messages.NO_SPACE_BEFORE);
     }
 
     private void addExpectedCommaMessage(int line, int column, String msg) {

--- a/src/test/java/com/sleekbyte/tailor/functional/CommaWhitespaceTest.java
+++ b/src/test/java/com/sleekbyte/tailor/functional/CommaWhitespaceTest.java
@@ -79,6 +79,15 @@ public class CommaWhitespaceTest extends RuleTest {
         addExpectedCommaMessage(start + 4, 47, Messages.NO_SPACE_BEFORE);
         addExpectedCommaMessage(start + 13, 21, Messages.NO_SPACE_BEFORE);
         addExpectedCommaMessage(start + 18, 20, Messages.SPACE_AFTER);
+
+        // Tuple patterns
+        start = 213;
+        addExpectedCommaMessage(start, 7, Messages.SPACE_AFTER);
+        addExpectedCommaMessage(start, 17, Messages.NO_SPACE_BEFORE);
+        addExpectedCommaMessage(start + 2, 11, Messages.SPACE_AFTER);
+        addExpectedCommaMessage(start + 2, 11, Messages.NO_SPACE_BEFORE);
+        addExpectedCommaMessage(start + 2, 20, Messages.SPACE_AFTER);
+
     }
 
     private void addExpectedCommaMessage(int line, int column, String msg) {

--- a/src/test/java/com/sleekbyte/tailor/functional/CommaWhitespaceTest.java
+++ b/src/test/java/com/sleekbyte/tailor/functional/CommaWhitespaceTest.java
@@ -88,6 +88,13 @@ public class CommaWhitespaceTest extends RuleTest {
         addExpectedCommaMessage(start + 2, 11, Messages.NO_SPACE_BEFORE);
         addExpectedCommaMessage(start + 2, 20, Messages.SPACE_AFTER);
 
+        // Expression lists
+        start = 223;
+        addExpectedCommaMessage(start, 11, Messages.SPACE_AFTER);
+        addExpectedCommaMessage(start + 4, 11, Messages.SPACE_AFTER);
+        addExpectedCommaMessage(start + 4, 46, Messages.NO_SPACE_BEFORE);
+        addExpectedCommaMessage(start + 8, 46, Messages.NO_SPACE_BEFORE);
+
     }
 
     private void addExpectedCommaMessage(int line, int column, String msg) {

--- a/src/test/java/com/sleekbyte/tailor/functional/CommaWhitespaceTest.java
+++ b/src/test/java/com/sleekbyte/tailor/functional/CommaWhitespaceTest.java
@@ -95,12 +95,19 @@ public class CommaWhitespaceTest extends RuleTest {
         addExpectedCommaMessage(start + 4, 46, Messages.NO_SPACE_BEFORE);
         addExpectedCommaMessage(start + 8, 46, Messages.NO_SPACE_BEFORE);
 
-        // Array Literals
+        // Array literals
         start = 237;
         addExpectedCommaMessage(start, 37, Messages.NO_SPACE_BEFORE);
         addExpectedCommaMessage(start, 47, Messages.SPACE_AFTER);
         addExpectedCommaMessage(start + 2, 36, Messages.SPACE_AFTER);
         addExpectedCommaMessage(start + 6, 57, Messages.NO_SPACE_BEFORE);
+
+        // Dictionary literals
+        start = 247;
+        addExpectedCommaMessage(start, 60, Messages.NO_SPACE_BEFORE);
+        addExpectedCommaMessage(start + 2, 59, Messages.SPACE_AFTER);
+        addExpectedCommaMessage(start + 4, 59, Messages.SPACE_AFTER);
+        addExpectedCommaMessage(start + 8, 77, Messages.NO_SPACE_BEFORE);
     }
 
     private void addExpectedCommaMessage(int line, int column, String msg) {

--- a/src/test/java/com/sleekbyte/tailor/functional/CommaWhitespaceTest.java
+++ b/src/test/java/com/sleekbyte/tailor/functional/CommaWhitespaceTest.java
@@ -94,16 +94,17 @@ public class CommaWhitespaceTest extends RuleTest {
         addExpectedCommaMessage(start + 4, 11, Messages.SPACE_AFTER);
         addExpectedCommaMessage(start + 4, 46, Messages.NO_SPACE_BEFORE);
         addExpectedCommaMessage(start + 8, 46, Messages.NO_SPACE_BEFORE);
+        addExpectedCommaMessage(start + 16, 5, Messages.NO_SPACE_BEFORE);
 
         // Array literals
-        start = 237;
+        start = 246;
         addExpectedCommaMessage(start, 37, Messages.NO_SPACE_BEFORE);
         addExpectedCommaMessage(start, 47, Messages.SPACE_AFTER);
         addExpectedCommaMessage(start + 2, 36, Messages.SPACE_AFTER);
         addExpectedCommaMessage(start + 6, 57, Messages.NO_SPACE_BEFORE);
 
         // Dictionary literals
-        start = 247;
+        start = 259;
         addExpectedCommaMessage(start, 60, Messages.NO_SPACE_BEFORE);
         addExpectedCommaMessage(start + 2, 59, Messages.SPACE_AFTER);
         addExpectedCommaMessage(start + 4, 59, Messages.SPACE_AFTER);

--- a/src/test/java/com/sleekbyte/tailor/functional/RedundantParenthesesTest.java
+++ b/src/test/java/com/sleekbyte/tailor/functional/RedundantParenthesesTest.java
@@ -14,6 +14,11 @@ import org.mockito.runners.MockitoJUnitRunner;
 public class RedundantParenthesesTest extends RuleTest {
 
     @Override
+    protected String[] getCommandArgs() {
+        return new String[]{ "--only=redundant-parentheses" };
+    }
+    
+    @Override
     protected void addAllExpectedMsgs() {
         addExpectedMsg(3, 8, Severity.WARNING, Messages.CONDITIONAL_CLAUSE + Messages.ENCLOSED_PARENTHESES);
         addExpectedMsg(6, 13, Severity.WARNING, Messages.CONDITIONAL_CLAUSE + Messages.ENCLOSED_PARENTHESES);

--- a/src/test/swift/com/sleekbyte/tailor/functional/CommaWhitespaceTest.swift
+++ b/src/test/swift/com/sleekbyte/tailor/functional/CommaWhitespaceTest.swift
@@ -241,3 +241,15 @@ shoppingList += ["Chocolate Spread","Cheese", "Butter"]
 shoppingList += ["Chocolate Spread", "Cheese", "Butter",]
 
 shoppingList += ["Chocolate Spread", "Cheese", "Butter" ,]
+
+var airports: [String: String] = ["YYZ": "Toronto Pearson", "DUB": "Dublin"]
+
+var airports: [String: String] = ["YYZ": "Toronto Pearson" , "DUB": "Dublin"]
+
+var airports: [String: String] = ["YYZ": "Toronto Pearson",  "DUB": "Dublin"]
+
+var airports: [String: String] = ["YYZ": "Toronto Pearson","DUB": "Dublin"]
+
+var airports: [String: String] = ["YYZ": "Toronto Pearson", "DUB": "Dublin",]
+
+var airports: [String: String] = ["YYZ": "Toronto Pearson", "DUB": "Dublin" ,]

--- a/src/test/swift/com/sleekbyte/tailor/functional/CommaWhitespaceTest.swift
+++ b/src/test/swift/com/sleekbyte/tailor/functional/CommaWhitespaceTest.swift
@@ -232,6 +232,15 @@ for (i = 0, j = n - 1; i < n && j >= 0; i++  , j--) {
   println(mat[i][j])
 }
 
+for (var i = 0,
+    j = 300 - 1;
+    i < 29 && j >= 0;
+    i++
+    ,
+    j--) {
+  println(mat[i][j])
+}
+
 shoppingList += ["Chocolate Spread", "Cheese", "Butter"]
 
 shoppingList += ["Chocolate Spread" , "Cheese",  "Butter"]
@@ -241,6 +250,9 @@ shoppingList += ["Chocolate Spread","Cheese", "Butter"]
 shoppingList += ["Chocolate Spread", "Cheese", "Butter",]
 
 shoppingList += ["Chocolate Spread", "Cheese", "Butter" ,]
+
+shoppingList += ["Chocolate Spread", "Cheese",
+ "Butter"]
 
 var airports: [String: String] = ["YYZ": "Toronto Pearson", "DUB": "Dublin"]
 

--- a/src/test/swift/com/sleekbyte/tailor/functional/CommaWhitespaceTest.swift
+++ b/src/test/swift/com/sleekbyte/tailor/functional/CommaWhitespaceTest.swift
@@ -215,3 +215,19 @@ var (x,y): (Int , Int)
 var (x, y ,z): (Int,Int, Int)
 
 var (x): Int = 2
+
+for (i = 0, j = n - 1; i < n && j >= 0; i++, j--) {
+  println(mat[i][j])
+}
+
+for (i = 0,j = n - 1; i < n && j >= 0; i++, j--) {
+  println(mat[i][j])
+}
+
+for (i = 0,  j = n - 1; i < n && j >= 0; i++ , j--) {
+  println(mat[i][j])
+}
+
+for (i = 0, j = n - 1; i < n && j >= 0; i++  , j--) {
+  println(mat[i][j])
+}

--- a/src/test/swift/com/sleekbyte/tailor/functional/CommaWhitespaceTest.swift
+++ b/src/test/swift/com/sleekbyte/tailor/functional/CommaWhitespaceTest.swift
@@ -231,3 +231,13 @@ for (i = 0,  j = n - 1; i < n && j >= 0; i++ , j--) {
 for (i = 0, j = n - 1; i < n && j >= 0; i++  , j--) {
   println(mat[i][j])
 }
+
+shoppingList += ["Chocolate Spread", "Cheese", "Butter"]
+
+shoppingList += ["Chocolate Spread" , "Cheese",  "Butter"]
+
+shoppingList += ["Chocolate Spread","Cheese", "Butter"]
+
+shoppingList += ["Chocolate Spread", "Cheese", "Butter",]
+
+shoppingList += ["Chocolate Spread", "Cheese", "Butter" ,]

--- a/src/test/swift/com/sleekbyte/tailor/functional/CommaWhitespaceTest.swift
+++ b/src/test/swift/com/sleekbyte/tailor/functional/CommaWhitespaceTest.swift
@@ -207,3 +207,11 @@ enum ASCIIControlCharacter: Character {
     case Tab = "\t",LineFeed = "\n"
     case CarriageReturn = "\r"
 }
+
+var (x, y): (Int, Int)
+
+var (x,y): (Int , Int)
+
+var (x, y ,z): (Int,Int, Int)
+
+var (x): Int = 2


### PR DESCRIPTION
Addresses #240.

Adds comma whitespace checks for the following constructs:

- tuple pattern list
- tuple type list
- expression list
- array literal items
- dictionary literal items