### PR TITLE
#240: Comma Whitespace Checks #4

### DIFF
--- a/src/main/antlr/com/sleekbyte/tailor/antlr/Swift.g4
+++ b/src/main/antlr/com/sleekbyte/tailor/antlr/Swift.g4
@@ -635,7 +635,7 @@ implicitMemberExpression : '.' identifier  ;
 // GRAMMAR OF A PARENTHESIZED EXPRESSION
 
 parenthesizedExpression : '(' expressionElementList? ')'  ;
-expressionElementList : expressionElement (',' expressionElementList)*  ;
+expressionElementList : expressionElement (',' expressionElement)*  ;
 expressionElement : expression | identifier ':' expression  ;
 
 // GRAMMAR OF A WILDCARD EXPRESSION

--- a/src/main/antlr/com/sleekbyte/tailor/antlr/Swift.g4
+++ b/src/main/antlr/com/sleekbyte/tailor/antlr/Swift.g4
@@ -895,7 +895,7 @@ Identifier : IdentifierHead IdentifierCharacters?
  | ImplicitParameterName
  ;
 
-identifierList : (identifier | '_') | (identifier | '_') ',' identifierList  ;
+identifierList : (identifier | '_') (',' (identifier | '_'))*  ;
 
 fragment IdentifierHead : [a-zA-Z] | '_'
  | '\u00A8' | '\u00AA' | '\u00AD' | '\u00AF' | [\u00B2-\u00B5] | [\u00B7-\u00BA]

--- a/src/main/antlr/com/sleekbyte/tailor/antlr/Swift.g4
+++ b/src/main/antlr/com/sleekbyte/tailor/antlr/Swift.g4
@@ -104,7 +104,8 @@ switchStatement : 'switch' expression '{' switchCases? '}'  ;
 switchCases : switchCase switchCases? ;
 switchCase : caseLabel statements | defaultLabel statements  | caseLabel ';' | defaultLabel ';'  ;
 caseLabel : 'case' caseItemList ':' ;
-caseItemList : pattern whereClause? | pattern whereClause? ',' caseItemList ;
+caseItemList : caseItem (',' caseItem)* ;
+caseItem: pattern whereClause? ;
 defaultLabel : 'default' ':' ;
 
 // GRAMMAR OF A LABELED STATEMENT

--- a/src/main/java/com/sleekbyte/tailor/listeners/whitespace/CommaWhitespaceListener.java
+++ b/src/main/java/com/sleekbyte/tailor/listeners/whitespace/CommaWhitespaceListener.java
@@ -5,6 +5,7 @@ import com.sleekbyte.tailor.antlr.SwiftParser;
 import com.sleekbyte.tailor.antlr.SwiftParser.ArrayLiteralItemsContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.AvailabilityArgumentsContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.CaptureListItemsContext;
+import com.sleekbyte.tailor.antlr.SwiftParser.CaseItemListContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.ConditionClauseContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.DictionaryLiteralItemsContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.ExpressionElementListContext;
@@ -162,6 +163,11 @@ public final class CommaWhitespaceListener extends SwiftBaseListener {
 
     @Override
     public void enterIdentifierList(IdentifierListContext ctx) {
+        checkWhitespaceAroundCommaSeparatedList(ctx);
+    }
+
+    @Override
+    public void enterCaseItemList(CaseItemListContext ctx) {
         checkWhitespaceAroundCommaSeparatedList(ctx);
     }
 

--- a/src/main/java/com/sleekbyte/tailor/listeners/whitespace/CommaWhitespaceListener.java
+++ b/src/main/java/com/sleekbyte/tailor/listeners/whitespace/CommaWhitespaceListener.java
@@ -10,6 +10,7 @@ import com.sleekbyte.tailor.antlr.SwiftParser.DictionaryLiteralItemsContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.ExpressionElementListContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.ExpressionListContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.GenericArgumentListContext;
+import com.sleekbyte.tailor.antlr.SwiftParser.IdentifierListContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.OptionalBindingConditionContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.ParameterListContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.PatternInitializerListContext;
@@ -156,6 +157,11 @@ public final class CommaWhitespaceListener extends SwiftBaseListener {
 
     @Override
     public void enterExpressionElementList(ExpressionElementListContext ctx) {
+        checkWhitespaceAroundCommaSeparatedList(ctx);
+    }
+
+    @Override
+    public void enterIdentifierList(IdentifierListContext ctx) {
         checkWhitespaceAroundCommaSeparatedList(ctx);
     }
 

--- a/src/main/java/com/sleekbyte/tailor/listeners/whitespace/CommaWhitespaceListener.java
+++ b/src/main/java/com/sleekbyte/tailor/listeners/whitespace/CommaWhitespaceListener.java
@@ -7,6 +7,7 @@ import com.sleekbyte.tailor.antlr.SwiftParser.AvailabilityArgumentsContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.CaptureListItemsContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.ConditionClauseContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.DictionaryLiteralItemsContext;
+import com.sleekbyte.tailor.antlr.SwiftParser.ExpressionElementListContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.ExpressionListContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.GenericArgumentListContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.OptionalBindingConditionContext;
@@ -150,6 +151,11 @@ public final class CommaWhitespaceListener extends SwiftBaseListener {
 
     @Override
     public void enterCaptureListItems(CaptureListItemsContext ctx) {
+        checkWhitespaceAroundCommaSeparatedList(ctx);
+    }
+
+    @Override
+    public void enterExpressionElementList(ExpressionElementListContext ctx) {
         checkWhitespaceAroundCommaSeparatedList(ctx);
     }
 

--- a/src/main/java/com/sleekbyte/tailor/listeners/whitespace/CommaWhitespaceListener.java
+++ b/src/main/java/com/sleekbyte/tailor/listeners/whitespace/CommaWhitespaceListener.java
@@ -4,6 +4,7 @@ import com.sleekbyte.tailor.antlr.SwiftBaseListener;
 import com.sleekbyte.tailor.antlr.SwiftParser;
 import com.sleekbyte.tailor.antlr.SwiftParser.ArrayLiteralItemsContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.AvailabilityArgumentsContext;
+import com.sleekbyte.tailor.antlr.SwiftParser.CaptureListItemsContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.ConditionClauseContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.DictionaryLiteralItemsContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.ExpressionListContext;
@@ -144,6 +145,11 @@ public final class CommaWhitespaceListener extends SwiftBaseListener {
 
     @Override
     public void enterDictionaryLiteralItems(DictionaryLiteralItemsContext ctx) {
+        checkWhitespaceAroundCommaSeparatedList(ctx);
+    }
+
+    @Override
+    public void enterCaptureListItems(CaptureListItemsContext ctx) {
         checkWhitespaceAroundCommaSeparatedList(ctx);
     }
 

--- a/src/test/java/com/sleekbyte/tailor/functional/CommaWhitespaceTest.java
+++ b/src/test/java/com/sleekbyte/tailor/functional/CommaWhitespaceTest.java
@@ -115,6 +115,14 @@ public class CommaWhitespaceTest extends RuleTest {
         addExpectedCommaMessage(start, 18, Messages.SPACE_AFTER);
         addExpectedCommaMessage(start + 5, 19, Messages.NO_SPACE_BEFORE);
         addExpectedCommaMessage(start + 10, 18, Messages.SPACE_AFTER);
+
+        // Parenthesized Expressions
+        start = 296;
+        addExpectedCommaMessage(start, 15, Messages.SPACE_AFTER);
+        addExpectedCommaMessage(start, 26, Messages.NO_SPACE_BEFORE);
+        addExpectedCommaMessage(start + 1, 18, Messages.SPACE_AFTER);
+        addExpectedCommaMessage(start + 8, 23, Messages.NO_SPACE_BEFORE);
+        addExpectedCommaMessage(start + 15, 22, Messages.SPACE_AFTER);
     }
 
     private void addExpectedCommaMessage(int line, int column, String msg) {

--- a/src/test/java/com/sleekbyte/tailor/functional/CommaWhitespaceTest.java
+++ b/src/test/java/com/sleekbyte/tailor/functional/CommaWhitespaceTest.java
@@ -123,6 +123,13 @@ public class CommaWhitespaceTest extends RuleTest {
         addExpectedCommaMessage(start + 1, 18, Messages.SPACE_AFTER);
         addExpectedCommaMessage(start + 8, 23, Messages.NO_SPACE_BEFORE);
         addExpectedCommaMessage(start + 15, 22, Messages.SPACE_AFTER);
+
+        // Identifier List
+        start = 315;
+        addExpectedCommaMessage(start, 28, Messages.SPACE_AFTER);
+        addExpectedCommaMessage(start + 1, 29, Messages.NO_SPACE_BEFORE);
+        addExpectedCommaMessage(start + 3, 28, Messages.NO_SPACE_BEFORE);
+        addExpectedCommaMessage(start + 3, 32, Messages.SPACE_AFTER);
     }
 
     private void addExpectedCommaMessage(int line, int column, String msg) {

--- a/src/test/java/com/sleekbyte/tailor/functional/CommaWhitespaceTest.java
+++ b/src/test/java/com/sleekbyte/tailor/functional/CommaWhitespaceTest.java
@@ -109,6 +109,12 @@ public class CommaWhitespaceTest extends RuleTest {
         addExpectedCommaMessage(start + 2, 59, Messages.SPACE_AFTER);
         addExpectedCommaMessage(start + 4, 59, Messages.SPACE_AFTER);
         addExpectedCommaMessage(start + 8, 77, Messages.NO_SPACE_BEFORE);
+
+        // Capture lists
+        start = 275;
+        addExpectedCommaMessage(start, 18, Messages.SPACE_AFTER);
+        addExpectedCommaMessage(start + 5, 19, Messages.NO_SPACE_BEFORE);
+        addExpectedCommaMessage(start + 10, 18, Messages.SPACE_AFTER);
     }
 
     private void addExpectedCommaMessage(int line, int column, String msg) {

--- a/src/test/java/com/sleekbyte/tailor/functional/CommaWhitespaceTest.java
+++ b/src/test/java/com/sleekbyte/tailor/functional/CommaWhitespaceTest.java
@@ -130,6 +130,13 @@ public class CommaWhitespaceTest extends RuleTest {
         addExpectedCommaMessage(start + 1, 29, Messages.NO_SPACE_BEFORE);
         addExpectedCommaMessage(start + 3, 28, Messages.NO_SPACE_BEFORE);
         addExpectedCommaMessage(start + 3, 32, Messages.SPACE_AFTER);
+
+        // Case Item List
+        start = 326;
+        addExpectedCommaMessage(start, 10, Messages.NO_SPACE_BEFORE);
+        addExpectedCommaMessage(start, 15, Messages.SPACE_AFTER);
+        addExpectedCommaMessage(start, 21, Messages.SPACE_AFTER);
+        addExpectedCommaMessage(start + 6, 6, Messages.SPACE_AFTER);
     }
 
     private void addExpectedCommaMessage(int line, int column, String msg) {

--- a/src/test/swift/com/sleekbyte/tailor/functional/CommaWhitespaceTest.swift
+++ b/src/test/swift/com/sleekbyte/tailor/functional/CommaWhitespaceTest.swift
@@ -316,3 +316,19 @@ reversed = names.sort( { s1,s2 in s1 > s2 } )
 reversed = names.sort( { s1 , s2 in s1 > s2 } )
 reversed = names.sort( { _, s1, s2 in s1 > s2 } )
 reversed = names.sort( { _ , s1,  s2 in s1 > s2 } )
+
+switch character {
+case "a", "e", "i", "o", "u", " ": continue
+default: puzzleOutput.append(character)
+}
+
+switch character {
+case "a" , "e",  "i","o", "u", " ": continue
+default: puzzleOutput.append(character)
+}
+
+switch character {
+case "a", "e", "i", "o",
+  "u"," ": continue
+default: puzzleOutput.append(character)
+}

--- a/src/test/swift/com/sleekbyte/tailor/functional/CommaWhitespaceTest.swift
+++ b/src/test/swift/com/sleekbyte/tailor/functional/CommaWhitespaceTest.swift
@@ -291,3 +291,22 @@ lazy var someClosure: Void -> String = {
      weak delegate = self.delegate!] in
     // closure body goes here
 }
+
+var arr = [ (1, 2, 3), (3, 4, 5) ]
+var arr = [ (1,2, 3), (3 , 4, 5) ]
+var arr = [ (1, 2,  3), (3, 4,
+  5) ]
+
+func getFullName() -> (first: String, last: String) {
+    let firstName = "John"
+    let lastName = "Doe"
+
+    return (firstName , lastName)
+}
+
+func getFullName() -> (first: String, last: String) {
+    let firstName = "John"
+    let lastName = "Doe"
+
+    return (firstName,lastName)
+}

--- a/src/test/swift/com/sleekbyte/tailor/functional/CommaWhitespaceTest.swift
+++ b/src/test/swift/com/sleekbyte/tailor/functional/CommaWhitespaceTest.swift
@@ -310,3 +310,9 @@ func getFullName() -> (first: String, last: String) {
 
     return (firstName,lastName)
 }
+
+reversed = names.sort( { s1, s2 in s1 > s2 } )
+reversed = names.sort( { s1,s2 in s1 > s2 } )
+reversed = names.sort( { s1 , s2 in s1 > s2 } )
+reversed = names.sort( { _, s1, s2 in s1 > s2 } )
+reversed = names.sort( { _ , s1,  s2 in s1 > s2 } )

--- a/src/test/swift/com/sleekbyte/tailor/functional/CommaWhitespaceTest.swift
+++ b/src/test/swift/com/sleekbyte/tailor/functional/CommaWhitespaceTest.swift
@@ -265,3 +265,29 @@ var airports: [String: String] = ["YYZ": "Toronto Pearson","DUB": "Dublin"]
 var airports: [String: String] = ["YYZ": "Toronto Pearson", "DUB": "Dublin",]
 
 var airports: [String: String] = ["YYZ": "Toronto Pearson", "DUB": "Dublin" ,]
+
+lazy var someClosure: Void -> String = {
+    [unowned self, weak delegate = self.delegate!] in
+    // closure body goes here
+}
+
+lazy var someClosure: Void -> String = {
+    [unowned self,weak delegate = self.delegate!] in
+    // closure body goes here
+}
+
+lazy var someClosure: Void -> String = {
+    [unowned self , weak delegate = self.delegate!] in
+    // closure body goes here
+}
+
+lazy var someClosure: Void -> String = {
+    [unowned self,  weak delegate = self.delegate!] in
+    // closure body goes here
+}
+
+lazy var someClosure: Void -> String = {
+    [unowned self,
+     weak delegate = self.delegate!] in
+    // closure body goes here
+}


### PR DESCRIPTION
Resolves #240.

Adds comma whitespace checks for the following constructs

- capture list items
- parenthesized expressions
- identifier list
- switch case item list