### PR TITLE
#300: Fix colon whitespace check for conditional operators

### DIFF
--- a/src/main/java/com/sleekbyte/tailor/listeners/whitespace/ColonWhitespaceListener.java
+++ b/src/main/java/com/sleekbyte/tailor/listeners/whitespace/ColonWhitespaceListener.java
@@ -87,7 +87,7 @@ public final class ColonWhitespaceListener extends SwiftBaseListener {
 
     @Override
     public void enterConditionalOperator(SwiftParser.ConditionalOperatorContext ctx) {
-        Token colon = ((TerminalNodeImpl) ctx.getChild(2)).getSymbol();
+        Token colon = ((TerminalNodeImpl) ctx.getChild(ctx.getChildCount() - 1)).getSymbol();
         Token left = ctx.expression().getStop();
         Token right = ((ParserRuleContext) ParseTreeUtil.getRightSibling(ctx)).getStart();
 

--- a/src/test/java/com/sleekbyte/tailor/functional/ColonWhitespaceTest.java
+++ b/src/test/java/com/sleekbyte/tailor/functional/ColonWhitespaceTest.java
@@ -99,9 +99,10 @@ public class ColonWhitespaceTest extends RuleTest {
         addExpectedMessage(start + 2, 15, Messages.SPACE_AFTER);
         addExpectedMessage(start + 4, 30, Messages.SPACE_BEFORE);
         addExpectedMessage(start + 5, 31, Messages.SPACE_AFTER);
+        addExpectedMessage(start + 7, 52, Messages.SPACE_BEFORE);
 
         // tuples
-        start = 165;
+        start = 167;
         addExpectedMessage(start + 1, 33, Messages.NO_SPACE_BEFORE);
         addExpectedMessage(start + 1, 51, Messages.SPACE_AFTER);
         addExpectedMessage(start + 2, 32, Messages.SPACE_AFTER);
@@ -109,7 +110,7 @@ public class ColonWhitespaceTest extends RuleTest {
         addExpectedMessage(start + 3, 83, Messages.SPACE_AFTER);
 
         // generics
-        start = 170;
+        start = 172;
         addExpectedMessage(start + 3, 21, Messages.NO_SPACE_BEFORE);
         addExpectedMessage(start + 3, 35, Messages.SPACE_AFTER);
         addExpectedMessage(start + 6, 20, Messages.SPACE_AFTER);

--- a/src/test/swift/com/sleekbyte/tailor/functional/ColonWhitespaceTest.swift
+++ b/src/test/swift/com/sleekbyte/tailor/functional/ColonWhitespaceTest.swift
@@ -161,6 +161,8 @@ a != nil ? a! :  b
 let light = status ? getRed() : getGreen()
 let light = status ? getRed(): getGreen()
 let light = status ? getRed() :  getGreen()
+let boolValue = lhs.boolValue ? try rhs().boolValue : false
+let boolValue = lhs.boolValue ? try rhs().boolValue: false
 
 let http200Status = (statusCode: 200, description: "OK")
 let http200Status = (statusCode : 200, description:"OK")


### PR DESCRIPTION
Resolves #300.

The colon whitespace check for colons in conditional statements did not handle the case where a `try` operator is present.