### PR TITLE
#305: Relax lowerCamelCase rule for constants with acronyms

### DIFF
--- a/src/main/java/com/sleekbyte/tailor/listeners/ConstantNamingListener.java
+++ b/src/main/java/com/sleekbyte/tailor/listeners/ConstantNamingListener.java
@@ -30,12 +30,14 @@ public class ConstantNamingListener extends SwiftBaseListener {
         if (ConstantDecHelper.isGlobal(constantDecContext)
                 || ConstantDecHelper.insideClass(constantDecContext)
                 || ConstantDecHelper.insideStruct(constantDecContext)) {
-            if (!CharFormatUtil.isUpperCamelCase(constantName) && !CharFormatUtil.isLowerCamelCase(constantName)) {
+            if (!CharFormatUtil.isUpperCamelCase(constantName)
+                && !CharFormatUtil.startsWithAcronym(constantName)
+                && !CharFormatUtil.isLowerCamelCase(constantName)) {
                 printer.error(Rules.CONSTANT_NAMING, Messages.GLOBAL + Messages.CONSTANT
                     + Messages.GLOBAL_CONSTANT_NAMING, location);
             }
         } else {
-            if (!CharFormatUtil.isLowerCamelCase(constantName)) {
+            if (!CharFormatUtil.startsWithAcronym(constantName) && !CharFormatUtil.isLowerCamelCase(constantName)) {
                 printer.error(Rules.CONSTANT_NAMING, Messages.CONSTANT + Messages.LOWER_CAMEL_CASE, location);
             }
         }

--- a/src/main/java/com/sleekbyte/tailor/listeners/ConstantNamingListener.java
+++ b/src/main/java/com/sleekbyte/tailor/listeners/ConstantNamingListener.java
@@ -31,13 +31,12 @@ public class ConstantNamingListener extends SwiftBaseListener {
                 || ConstantDecHelper.insideClass(constantDecContext)
                 || ConstantDecHelper.insideStruct(constantDecContext)) {
             if (!CharFormatUtil.isUpperCamelCase(constantName)
-                && !CharFormatUtil.startsWithAcronym(constantName)
-                && !CharFormatUtil.isLowerCamelCase(constantName)) {
+                && !CharFormatUtil.isLowerCamelCaseOrAcronym(constantName)) {
                 printer.error(Rules.CONSTANT_NAMING, Messages.GLOBAL + Messages.CONSTANT
                     + Messages.GLOBAL_CONSTANT_NAMING, location);
             }
         } else {
-            if (!CharFormatUtil.startsWithAcronym(constantName) && !CharFormatUtil.isLowerCamelCase(constantName)) {
+            if (!CharFormatUtil.isLowerCamelCaseOrAcronym(constantName)) {
                 printer.error(Rules.CONSTANT_NAMING, Messages.CONSTANT + Messages.LOWER_CAMEL_CASE, location);
             }
         }

--- a/src/main/java/com/sleekbyte/tailor/listeners/LowerCamelCaseListener.java
+++ b/src/main/java/com/sleekbyte/tailor/listeners/LowerCamelCaseListener.java
@@ -48,7 +48,7 @@ public class LowerCamelCaseListener extends SwiftBaseListener {
 
     private void verifyLowerCamelCase(String constructType, ParserRuleContext ctx) {
         String constructName = ctx.getText();
-        if (!CharFormatUtil.startsWithAcronym(constructName) && !CharFormatUtil.isLowerCamelCase(constructName)) {
+        if (!CharFormatUtil.isLowerCamelCaseOrAcronym(constructName)) {
             Location location = ListenerUtil.getContextStartLocation(ctx);
             this.printer.error(Rules.LOWER_CAMEL_CASE, constructType + Messages.LOWER_CAMEL_CASE, location);
         }

--- a/src/main/java/com/sleekbyte/tailor/utils/CharFormatUtil.java
+++ b/src/main/java/com/sleekbyte/tailor/utils/CharFormatUtil.java
@@ -20,6 +20,10 @@ public class CharFormatUtil {
             && word.matches(ALPHANUMERIC_REGEX);
     }
 
+    public static boolean isLowerCamelCaseOrAcronym(String word) {
+        return startsWithAcronym(word) || isLowerCamelCase(word);
+    }
+
     /**
      * Checks if a name is prefixed with a 'k' or 'K'.
      *

--- a/src/test/java/com/sleekbyte/tailor/functional/ConstantNamingTest.java
+++ b/src/test/java/com/sleekbyte/tailor/functional/ConstantNamingTest.java
@@ -23,7 +23,6 @@ public class ConstantNamingTest extends RuleTest {
             + Messages.K_PREFIXED);
         addExpectedMsg(Rules.CONSTANT_K_PREFIX, 5, 16, Severity.WARNING, Messages.CONSTANT + Messages.NAME
             + Messages.K_PREFIXED);
-        addExpectedMsg(Rules.CONSTANT_NAMING, 5, 16, Severity.WARNING, Messages.CONSTANT + Messages.LOWER_CAMEL_CASE);
         addExpectedMsg(Rules.CONSTANT_NAMING, 5, 45, Severity.WARNING, Messages.CONSTANT + Messages.LOWER_CAMEL_CASE);
         addExpectedMsg(Rules.CONSTANT_NAMING, 11, 13, Severity.WARNING, Messages.GLOBAL + Messages.CONSTANT
             + Messages.GLOBAL_CONSTANT_NAMING);
@@ -63,7 +62,6 @@ public class ConstantNamingTest extends RuleTest {
             + Messages.K_PREFIXED);
         addExpectedMsg(Rules.CONSTANT_K_PREFIX, 134, 20, Severity.WARNING, Messages.CONSTANT + Messages.NAME
             + Messages.K_PREFIXED);
-        addExpectedMsg(Rules.CONSTANT_NAMING, 134, 20, Severity.WARNING, Messages.CONSTANT + Messages.LOWER_CAMEL_CASE);
     }
 
     @Override

--- a/src/test/swift/com/sleekbyte/tailor/functional/ConstantNamingTest.swift
+++ b/src/test/swift/com/sleekbyte/tailor/functional/ConstantNamingTest.swift
@@ -131,7 +131,18 @@ private struct Scaling {
     func sup() {
         static let faceRadiusToMouthWidthRatio: CGFloat = 1
         static let kFaceRadiusToMouthHeightRatio: CGFloat = 3
-        static let KFaceRadiusToMouthOffsetRatio: CGFloat = 3
+        static let kFaceRadiusToMouthOffsetRatio: CGFloat = 3
+    }
+
+    let URL = "https://tailor.sh"
+
+    init?(URL url: NSURL, resolvingAgainstBaseURL resolve: Bool) {
+    }
+    convenience init(URL URL: NSURL) {
+    }
+    init(URL URL: NSURL, entersReaderIfAvailable entersReaderIfAvailable: Bool) {
+    }
+    init?(URL url: NSURL, statusCode statusCode: Int, HTTPVersion HTTPVersion: String?, headerFields headerFields: [String: String]?) {
     }
 
 }


### PR DESCRIPTION
Addresses #305.