### PR TITLE
#354: Add #selector rule to the grammar

### DIFF
--- a/src/main/antlr/com/sleekbyte/tailor/antlr/Swift.g4
+++ b/src/main/antlr/com/sleekbyte/tailor/antlr/Swift.g4
@@ -674,7 +674,7 @@ postfixExpression
 
 // GRAMMAR OF AN ARGUMENT NAME
 argumentNames : argumentName argumentNames?  ;
-argumentName: (identifier | '_') ':'? ;
+argumentName: (identifier | '_') ':'?  ; // Swift Language Reference has argumentName → identifier :
 
 // GRAMMAR OF A FUNCTION CALL EXPRESSION
 
@@ -695,9 +695,6 @@ explicitMemberExpression
   | postfixExpression '.' identifier genericArgumentClause?
   | postfixExpression '.' identifier '(' argumentNames ')'
   ;
-
-argumentNames : argumentName argumentNames?  ;
-argumentName : identifier ':'  ;
 */
 
 //postfix_self_expression : postfix_expression '.' 'self' ;

--- a/src/main/antlr/com/sleekbyte/tailor/antlr/Swift.g4
+++ b/src/main/antlr/com/sleekbyte/tailor/antlr/Swift.g4
@@ -574,6 +574,7 @@ primaryExpression
  | implicitMemberExpression
 // | implicit_member_expression disallow as ambig with explicit member expr in postfix_expression
  | wildcardExpression
+ | selectorExpression
  ;
 
 // GRAMMAR OF A LITERAL EXPRESSION
@@ -645,6 +646,10 @@ expressionElement : expression | identifier ':' expression  ;
 // GRAMMAR OF A WILDCARD EXPRESSION
 
 wildcardExpression : '_'  ;
+
+// GRAMMAR OF A SELECTOR EXPRESSION
+
+selectorExpression: '#selector' '('expression')'  ;
 
 // GRAMMAR OF A POSTFIX EXPRESSION
 

--- a/src/main/antlr/com/sleekbyte/tailor/antlr/Swift.g4
+++ b/src/main/antlr/com/sleekbyte/tailor/antlr/Swift.g4
@@ -662,7 +662,8 @@ postfixExpression
  | postfixExpression '.' 'init'                                  # initializerExpression
  // TODO: don't allow '_' here in DecimalLiteral:
  | postfixExpression '.' DecimalLiteral                         # explicitMemberExpression1
- | postfixExpression '.' identifier genericArgumentClause?     # explicitMemberExpression2
+ | postfixExpression '.' identifier genericArgumentClause?      # explicitMemberExpression2
+ | postfixExpression '.' identifier '(' argumentNames ')'       # explicitMemberExpression3
  | postfixExpression '.' 'self'                                  # postfixSelfExpression
  | postfixExpression '.' 'dynamicType'                           # dynamicTypeExpression
  // Swift Language Reference uses expressionList
@@ -670,6 +671,10 @@ postfixExpression
  | postfixExpression '!'                                # forcedValueExpression
  | postfixExpression '?'                                         # optionalChainingExpression
  ;
+
+// GRAMMAR OF AN ARGUMENT NAME
+argumentNames : argumentName argumentNames?  ;
+argumentName: (identifier | '_') ':'? ;
 
 // GRAMMAR OF A FUNCTION CALL EXPRESSION
 
@@ -684,11 +689,16 @@ functionCallExpression
 
 //initializer_expression : postfix_expression '.' 'init' ;
 
-/*explicitMemberExpression
+/*
+explicitMemberExpression
   : postfixExpression '.' DecimalLiteral // TODO: don't allow '_' here in DecimalLiteral
   | postfixExpression '.' identifier genericArgumentClause?
+  | postfixExpression '.' identifier '(' argumentNames ')'
   ;
-  */
+
+argumentNames : argumentName argumentNames?  ;
+argumentName : identifier ':'  ;
+*/
 
 //postfix_self_expression : postfix_expression '.' 'self' ;
 

--- a/src/main/antlr/com/sleekbyte/tailor/antlr/Swift.g4
+++ b/src/main/antlr/com/sleekbyte/tailor/antlr/Swift.g4
@@ -674,7 +674,7 @@ postfixExpression
 
 // GRAMMAR OF AN ARGUMENT NAME
 argumentNames : argumentName argumentNames?  ;
-argumentName: (identifier | '_') ':'?  ; // Swift Language Reference has argumentName → identifier :
+argumentName: (identifier | '_') ':'  ; // Swift Language Reference has argumentName → identifier :
 
 // GRAMMAR OF A FUNCTION CALL EXPRESSION
 

--- a/src/test/swift/com/sleekbyte/tailor/grammar/Macros.swift
+++ b/src/test/swift/com/sleekbyte/tailor/grammar/Macros.swift
@@ -89,4 +89,6 @@ func test() {
                         userInfo: nil, repeats: false)
     button.addTarget(object, action: #selector(MyClass.buttonTapped),
                      forControlEvents: .TouchUpInside)
+    view.performSelector(#selector(UIView.insertSubview(_:aboveSubview:)),
+                         withObject: button, withObject: otherButton)
 }

--- a/src/test/swift/com/sleekbyte/tailor/grammar/Macros.swift
+++ b/src/test/swift/com/sleekbyte/tailor/grammar/Macros.swift
@@ -82,3 +82,11 @@ public var isRunningOnDevice: Bool = {
 		return true
 	#endif
 }()
+
+func test() {
+    let timer = NSTimer(timeInterval: 1, target: object,
+                        selector: #selector(MyClass.test),
+                        userInfo: nil, repeats: false)
+    button.addTarget(object, action: #selector(MyClass.buttonTapped),
+                     forControlEvents: .TouchUpInside)
+}


### PR DESCRIPTION
Fixes #354.  The `#selector` macro is a new feature introduced with Swift 2.2.

The grammar needs to be updated to incorporate new language features that have been added in Swift 2.2.