### PR TITLE
Attributes in Swift don't need a leading `@`

### DIFF
--- a/src/main/antlr/com/sleekbyte/tailor/antlr/Swift.g4
+++ b/src/main/antlr/com/sleekbyte/tailor/antlr/Swift.g4
@@ -271,8 +271,8 @@ variableDeclaration
 variableDeclarationHead : attributes? declarationModifiers? 'var'  ;
 variableName : identifier  ;
 getterSetterBlock : '{' getterClause setterClause?'}'  | '{' setterClause getterClause '}'  ;
-getterClause : attributes? 'get' codeBlock  ;
-setterClause : attributes? 'set' setterName? codeBlock  ;
+getterClause : attributes? declarationModifiers? 'get' codeBlock  ;
+setterClause : attributes? declarationModifiers? 'set' setterName? codeBlock  ;
 setterName : '(' identifier ')'  ;
 getterSetterKeywordBlock : '{' getterKeywordClause setterKeywordClause?'}' | '{' setterKeywordClause getterKeywordClause '}'  ;
 getterKeywordClause : attributes? 'get'  ;
@@ -477,7 +477,7 @@ expressionPattern : expression  ;
 
 // GRAMMAR OF AN ATTRIBUTE
 
-attribute : '@'? attributeName attributeArgumentClause? ;
+attribute : '@' attributeName attributeArgumentClause? ;
 attributeName : identifier ;
 attributeArgumentClause : '('  balancedTokens?  ')'  ;
 attributes : attribute+ ;

--- a/src/main/antlr/com/sleekbyte/tailor/antlr/Swift.g4
+++ b/src/main/antlr/com/sleekbyte/tailor/antlr/Swift.g4
@@ -477,7 +477,7 @@ expressionPattern : expression  ;
 
 // GRAMMAR OF AN ATTRIBUTE
 
-attribute : '@' attributeName attributeArgumentClause? ;
+attribute : '@'? attributeName attributeArgumentClause? ;
 attributeName : identifier ;
 attributeArgumentClause : '('  balancedTokens?  ')'  ;
 attributes : attribute+ ;


### PR DESCRIPTION
This change fixes the whole getters/setters business. Courtesy of codebeat.co ;)