### PR TITLE
#376: Update grammar to Swift 2.2

### DIFF
--- a/src/main/antlr/com/sleekbyte/tailor/antlr/Swift.g4
+++ b/src/main/antlr/com/sleekbyte/tailor/antlr/Swift.g4
@@ -62,10 +62,6 @@ loopStatement : forInStatement
  | repeatWhileStatement
  ;
 
-// GRAMMAR OF A FOR STATEMENT
-
-forInit : variableDeclaration | expressionList  ;
-
 // GRAMMAR OF A FOR_IN STATEMENT
 
 forInStatement : 'for' 'case'? pattern 'in' expression whereClause? codeBlock  ;
@@ -488,8 +484,6 @@ balancedToken
 // Expressions
 
 // GRAMMAR OF AN EXPRESSION
-
-expressionList : expression (',' expression)* ;
 
 expression : tryOperator? prefixExpression binaryExpression* ;
 

--- a/src/main/java/com/sleekbyte/tailor/listeners/BraceStyleListener.java
+++ b/src/main/java/com/sleekbyte/tailor/listeners/BraceStyleListener.java
@@ -50,11 +50,6 @@ public class BraceStyleListener extends SwiftBaseListener {
     }
 
     @Override
-    public void enterForStatement(SwiftParser.ForStatementContext ctx) {
-        verifyForLoopBraceStyle(ctx);
-    }
-
-    @Override
     public void enterFunctionDeclaration(SwiftParser.FunctionDeclarationContext ctx) {
         verifyFunctionBraceStyle(ctx);
     }
@@ -211,18 +206,6 @@ public class BraceStyleListener extends SwiftBaseListener {
     private void verifyStructBraceStyle(SwiftParser.StructBodyContext ctx) {
         verifyBodyOpenBraceStyle(ctx, Messages.STRUCT);
         verifyBodyCloseBraceStyle(ctx, Messages.STRUCT);
-    }
-
-    private void verifyForLoopBraceStyle(SwiftParser.ForStatementContext ctx) {
-        int numChildren = ctx.getChildCount();
-        Token loopEndToken;
-
-        // object at [numChildren - 1] index is codeBlock
-        // object at [numChildren - 2] index is either an expression or ';'
-        ParseTree constructBeforeOpenBrace = ctx.getChild(numChildren - 2);
-        loopEndToken = ParseTreeUtil.getStopTokenForNode(constructBeforeOpenBrace);
-        verifyCodeBlockOpenBraceStyle(ctx.codeBlock(), loopEndToken, Messages.FOR_LOOP);
-        verifyBodyCloseBraceStyle(ctx.codeBlock(), Messages.FOR_LOOP);
     }
 
     private void verifyProtocolBraceStyle(SwiftParser.ProtocolBodyContext ctx) {

--- a/src/main/java/com/sleekbyte/tailor/listeners/RedundantParenthesesListener.java
+++ b/src/main/java/com/sleekbyte/tailor/listeners/RedundantParenthesesListener.java
@@ -7,7 +7,6 @@ import com.sleekbyte.tailor.antlr.SwiftParser.CatchClauseContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.ConditionClauseContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.DictionaryLiteralItemContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.ExpressionContext;
-import com.sleekbyte.tailor.antlr.SwiftParser.ForStatementContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.FunctionCallWithClosureExpressionContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.InitializerContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.ParenthesizedExpressionContext;
@@ -21,8 +20,6 @@ import com.sleekbyte.tailor.common.Rules;
 import com.sleekbyte.tailor.output.Printer;
 import com.sleekbyte.tailor.utils.ListenerUtil;
 import org.antlr.v4.runtime.ParserRuleContext;
-import org.antlr.v4.runtime.Token;
-import org.antlr.v4.runtime.tree.TerminalNodeImpl;
 
 /**
  * Parse tree listener for redundant parentheses checks.
@@ -43,22 +40,6 @@ public class RedundantParenthesesListener extends SwiftBaseListener {
     @Override
     public void enterSwitchStatement(SwitchStatementContext ctx) {
         verifyRedundantExpressionParentheses(Messages.SWITCH_EXPRESSION, ctx.expression());
-    }
-
-    @Override
-    public void enterForStatement(ForStatementContext ctx) {
-        if (!(ctx.getChild(1) instanceof TerminalNodeImpl)) {
-            return;
-        } // return if '(' not present
-
-        Token openParenthesisToken = ((TerminalNodeImpl) ctx.getChild(1)).getSymbol();
-        char firstCharacter = openParenthesisToken.getText().charAt(0);
-
-        if (firstCharacter == '(') {
-            Location startLocation = ListenerUtil.getTokenLocation(openParenthesisToken);
-            this.printer.warn(Rules.REDUNDANT_PARENTHESES, Messages.FOR_LOOP + Messages.ENCLOSED_PARENTHESES,
-                startLocation);
-        }
     }
 
     @Override

--- a/src/main/java/com/sleekbyte/tailor/listeners/whitespace/CommaWhitespaceListener.java
+++ b/src/main/java/com/sleekbyte/tailor/listeners/whitespace/CommaWhitespaceListener.java
@@ -9,7 +9,6 @@ import com.sleekbyte.tailor.antlr.SwiftParser.CaseItemListContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.ConditionClauseContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.DictionaryLiteralItemsContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.ExpressionElementListContext;
-import com.sleekbyte.tailor.antlr.SwiftParser.ExpressionListContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.GenericArgumentListContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.IdentifierListContext;
 import com.sleekbyte.tailor.antlr.SwiftParser.OptionalBindingConditionContext;
@@ -133,11 +132,6 @@ public final class CommaWhitespaceListener extends SwiftBaseListener {
 
     @Override
     public void enterTupleTypeElementList(TupleTypeElementListContext ctx) {
-        checkWhitespaceAroundCommaSeparatedList(ctx);
-    }
-
-    @Override
-    public void enterExpressionList(ExpressionListContext ctx) {
         checkWhitespaceAroundCommaSeparatedList(ctx);
     }
 

--- a/src/main/java/com/sleekbyte/tailor/listeners/whitespace/ParenthesisWhitespaceListener.java
+++ b/src/main/java/com/sleekbyte/tailor/listeners/whitespace/ParenthesisWhitespaceListener.java
@@ -25,20 +25,7 @@ public final class ParenthesisWhitespaceListener extends SwiftBaseListener {
     @Override
     public void enterParameterClause(SwiftParser.ParameterClauseContext ctx) {
         verifier.verifyBracketContentWhitespace(ctx, Messages.PARENTHESES);
-    }
 
-    @Override
-    public void enterTupleType(SwiftParser.TupleTypeContext ctx) {
-        verifier.verifyBracketContentWhitespace(ctx, Messages.PARENTHESES);
-    }
-
-    @Override
-    public void enterParenthesizedExpression(SwiftParser.ParenthesizedExpressionContext ctx) {
-        verifier.verifyBracketContentWhitespace(ctx, Messages.PARENTHESES);
-    }
-
-    @Override
-    public void enterParameterClauses(SwiftParser.ParameterClausesContext ctx) {
         ParserRuleContext parent = ctx.getParent();
         if (parent instanceof FunctionSignatureContext) {
             ParseTree declaration = parent.getParent();
@@ -53,6 +40,16 @@ public final class ParenthesisWhitespaceListener extends SwiftBaseListener {
             }
         }
         verifier.verifyLeadingWhitespaceBeforeBracket(ctx, Messages.PARENTHESES, Messages.NO_WHITESPACE_BEFORE, 0);
+    }
+
+    @Override
+    public void enterTupleType(SwiftParser.TupleTypeContext ctx) {
+        verifier.verifyBracketContentWhitespace(ctx, Messages.PARENTHESES);
+    }
+
+    @Override
+    public void enterParenthesizedExpression(SwiftParser.ParenthesizedExpressionContext ctx) {
+        verifier.verifyBracketContentWhitespace(ctx, Messages.PARENTHESES);
     }
 
     @Override

--- a/src/test/java/com/sleekbyte/tailor/functional/BraceWhitespaceTest.java
+++ b/src/test/java/com/sleekbyte/tailor/functional/BraceWhitespaceTest.java
@@ -26,31 +26,27 @@ public class BraceWhitespaceTest extends RuleTest {
         addExpectedMsg(start + 6, 15);
 
         // loops
-        start = 35;
-        addExpectedMsg(start, 53);
+        start = 31;
         addExpectedMsg(start + 4, 38);
-        addExpectedMsg(start + 29, 22);
-        addExpectedMsg(start + 33, 17);
-        addExpectedMsg(start + 43, 17);
-        addExpectedMsg(start + 47, 26);
-        addExpectedMsg(start + 54, 22);
-        addExpectedMsg(start + 70, 20);
-        addExpectedMsg(start + 75, 18);
-        addExpectedMsg(start + 79, 71);
+        addExpectedMsg(start + 25, 22);
+        addExpectedMsg(start + 29, 17);
+        addExpectedMsg(start + 39, 17);
+        addExpectedMsg(start + 43, 26);
+        addExpectedMsg(start + 50, 71);
 
         // classes and structs with generic types
-        start = 126;
+        start = 93;
         addExpectedMsg(start, 6);
         addExpectedMsg(start + 3, 4);
 
         // protocols
-        start = 135;
+        start = 102;
         addExpectedMsg(start, 24);
         addExpectedMsg(start + 4, 32);
         addExpectedMsg(start + 13, 24);
 
         // enums
-        start = 162;
+        start = 129;
         addExpectedMsg(start, 16);
         addExpectedMsg(start + 4, 27);
         addExpectedMsg(start + 17, 6);
@@ -58,19 +54,19 @@ public class BraceWhitespaceTest extends RuleTest {
         addExpectedMsg(start + 34, 19);
 
         // closures
-        start = 200;
+        start = 167;
         addExpectedMsg(start, 29);
         addExpectedMsg(start + 14, 72);
         addExpectedMsg(start + 18, 17);
 
         // extensions
-        start = 236;
+        start = 203;
         addExpectedMsg(start, 26);
         addExpectedMsg(start + 4, 29);
         addExpectedMsg(start + 9, 19);
 
         // getters and setters
-        start = 250;
+        start = 217;
         addExpectedMsg(start, 8);
         addExpectedMsg(start + 4, 8);
         addExpectedMsg(start + 21, 14);

--- a/src/test/java/com/sleekbyte/tailor/functional/ClosingBraceLineTest.java
+++ b/src/test/java/com/sleekbyte/tailor/functional/ClosingBraceLineTest.java
@@ -47,29 +47,36 @@ public class ClosingBraceLineTest extends RuleTest {
         addExpectedBraceMsg(192, 38, Severity.WARNING, Messages.IF_STATEMENT);
         addExpectedBraceMsg(195, 35, Severity.WARNING, Messages.IF_STATEMENT);
         addExpectedBraceMsg(201, 44, Severity.WARNING, Messages.ELSE_CLAUSE);
-        addExpectedBraceMsg(209, 24, Severity.WARNING, Messages.FOR_LOOP);
-        addExpectedBraceMsg(212, 30, Severity.WARNING, Messages.FOR_IN_LOOP);
-        addExpectedBraceMsg(215, 47, Severity.WARNING, Messages.WHILE_STATEMENT);
-        addExpectedBraceMsg(217, 38, Severity.WARNING, Messages.REPEAT_WHILE_STATEMENT);
-        addExpectedBraceMsg(220, 18, Severity.WARNING, Messages.REPEAT_WHILE_STATEMENT);
-        addExpectedBraceMsg(224, 15, Severity.WARNING, Messages.FUNCTION);
-        addExpectedBraceMsg(226, 40, Severity.WARNING, Messages.FUNCTION);
-        addExpectedBraceMsg(239, 34, Severity.WARNING, Messages.CLOSURE);
-        addExpectedBraceMsg(247, 12, Severity.WARNING, Messages.CLOSURE);
-        addExpectedBraceMsg(260, 19, Severity.WARNING, Messages.ENUM);
-        addExpectedBraceMsg(268, 19, Severity.WARNING, Messages.ENUM);
-        addExpectedBraceMsg(275, 25, Severity.WARNING, Messages.ENUM);
-        addExpectedEmptyConstructBodyMsg(279, 15, Severity.WARNING);
-        addExpectedBraceMsg(285, 16, Severity.WARNING, Messages.CLOSURE);
-        addExpectedBraceMsg(295, 35, Severity.WARNING, Messages.SUBSCRIPT);
-        addExpectedBraceMsg(303, 10, Severity.WARNING, Messages.SUBSCRIPT);
-        addExpectedBraceMsg(329, 11, Severity.WARNING, Messages.GETTER_SETTER_BLOCK);
-        addExpectedBraceMsg(329, 11, Severity.WARNING, Messages.SUBSCRIPT);
-        addExpectedBraceMsg(335, 68, Severity.WARNING, Messages.WILL_SET_CLAUSE);
-        addExpectedBraceMsg(339, 15, Severity.WARNING, Messages.DID_SET_CLAUSE);
-        addExpectedBraceMsg(348, 15, Severity.WARNING, Messages.DID_SET_CLAUSE);
-        addExpectedBraceMsg(355, 68, Severity.WARNING, Messages.WILL_SET_CLAUSE);
-        addExpectedBraceMsg(363, 11, Severity.WARNING, Messages.WILLSET_DIDSET_BLOCK);
+
+        int start = 209;
+        addExpectedBraceMsg(start, 30, Severity.WARNING, Messages.FOR_IN_LOOP);
+        addExpectedBraceMsg(start + 3, 47, Severity.WARNING, Messages.WHILE_STATEMENT);
+        addExpectedBraceMsg(start + 5, 38, Severity.WARNING, Messages.REPEAT_WHILE_STATEMENT);
+        addExpectedBraceMsg(start + 8, 18, Severity.WARNING, Messages.REPEAT_WHILE_STATEMENT);
+
+        start = 221;
+        addExpectedBraceMsg(start, 15, Severity.WARNING, Messages.FUNCTION);
+        addExpectedBraceMsg(start + 2, 40, Severity.WARNING, Messages.FUNCTION);
+        addExpectedBraceMsg(start + 15, 34, Severity.WARNING, Messages.CLOSURE);
+        addExpectedBraceMsg(start + 23, 12, Severity.WARNING, Messages.CLOSURE);
+
+        start = 257;
+        addExpectedBraceMsg(start, 19, Severity.WARNING, Messages.ENUM);
+        addExpectedBraceMsg(start + 8, 19, Severity.WARNING, Messages.ENUM);
+        addExpectedBraceMsg(start + 15, 25, Severity.WARNING, Messages.ENUM);
+        addExpectedEmptyConstructBodyMsg(start + 19, 15, Severity.WARNING);
+        addExpectedBraceMsg(start + 25, 16, Severity.WARNING, Messages.CLOSURE);
+        addExpectedBraceMsg(start + 35, 35, Severity.WARNING, Messages.SUBSCRIPT);
+        addExpectedBraceMsg(start + 43, 10, Severity.WARNING, Messages.SUBSCRIPT);
+
+        start = 326;
+        addExpectedBraceMsg(start, 11, Severity.WARNING, Messages.GETTER_SETTER_BLOCK);
+        addExpectedBraceMsg(start, 11, Severity.WARNING, Messages.SUBSCRIPT);
+        addExpectedBraceMsg(start + 6, 68, Severity.WARNING, Messages.WILL_SET_CLAUSE);
+        addExpectedBraceMsg(start + 10, 15, Severity.WARNING, Messages.DID_SET_CLAUSE);
+        addExpectedBraceMsg(start + 19, 15, Severity.WARNING, Messages.DID_SET_CLAUSE);
+        addExpectedBraceMsg(start + 26, 68, Severity.WARNING, Messages.WILL_SET_CLAUSE);
+        addExpectedBraceMsg(start + 34, 11, Severity.WARNING, Messages.WILLSET_DIDSET_BLOCK);
     }
 
     private void addExpectedBraceMsg(int line, int column, Severity severity, String msg) {

--- a/src/test/java/com/sleekbyte/tailor/functional/CommaWhitespaceTest.java
+++ b/src/test/java/com/sleekbyte/tailor/functional/CommaWhitespaceTest.java
@@ -88,36 +88,28 @@ public class CommaWhitespaceTest extends RuleTest {
         addExpectedCommaMessage(start + 2, 11, Messages.NO_SPACE_BEFORE);
         addExpectedCommaMessage(start + 2, 20, Messages.SPACE_AFTER);
 
-        // Expression lists
-        start = 223;
-        addExpectedCommaMessage(start, 11, Messages.SPACE_AFTER);
-        addExpectedCommaMessage(start + 4, 11, Messages.SPACE_AFTER);
-        addExpectedCommaMessage(start + 4, 46, Messages.NO_SPACE_BEFORE);
-        addExpectedCommaMessage(start + 8, 46, Messages.NO_SPACE_BEFORE);
-        addExpectedCommaMessage(start + 16, 5, Messages.NO_SPACE_BEFORE);
-
         // Array literals
-        start = 246;
+        start = 221;
         addExpectedCommaMessage(start, 37, Messages.NO_SPACE_BEFORE);
         addExpectedCommaMessage(start, 47, Messages.SPACE_AFTER);
         addExpectedCommaMessage(start + 2, 36, Messages.SPACE_AFTER);
         addExpectedCommaMessage(start + 6, 57, Messages.NO_SPACE_BEFORE);
 
         // Dictionary literals
-        start = 259;
+        start = 234;
         addExpectedCommaMessage(start, 60, Messages.NO_SPACE_BEFORE);
         addExpectedCommaMessage(start + 2, 59, Messages.SPACE_AFTER);
         addExpectedCommaMessage(start + 4, 59, Messages.SPACE_AFTER);
         addExpectedCommaMessage(start + 8, 77, Messages.NO_SPACE_BEFORE);
 
         // Capture lists
-        start = 275;
+        start = 250;
         addExpectedCommaMessage(start, 18, Messages.SPACE_AFTER);
         addExpectedCommaMessage(start + 5, 19, Messages.NO_SPACE_BEFORE);
         addExpectedCommaMessage(start + 10, 18, Messages.SPACE_AFTER);
 
         // Parenthesized Expressions
-        start = 296;
+        start = 271;
         addExpectedCommaMessage(start, 15, Messages.SPACE_AFTER);
         addExpectedCommaMessage(start, 26, Messages.NO_SPACE_BEFORE);
         addExpectedCommaMessage(start + 1, 18, Messages.SPACE_AFTER);
@@ -125,14 +117,14 @@ public class CommaWhitespaceTest extends RuleTest {
         addExpectedCommaMessage(start + 15, 22, Messages.SPACE_AFTER);
 
         // Identifier List
-        start = 315;
+        start = 290;
         addExpectedCommaMessage(start, 28, Messages.SPACE_AFTER);
         addExpectedCommaMessage(start + 1, 29, Messages.NO_SPACE_BEFORE);
         addExpectedCommaMessage(start + 3, 28, Messages.NO_SPACE_BEFORE);
         addExpectedCommaMessage(start + 3, 32, Messages.SPACE_AFTER);
 
         // Case Item List
-        start = 326;
+        start = 301;
         addExpectedCommaMessage(start, 10, Messages.NO_SPACE_BEFORE);
         addExpectedCommaMessage(start, 15, Messages.SPACE_AFTER);
         addExpectedCommaMessage(start, 21, Messages.SPACE_AFTER);

--- a/src/test/java/com/sleekbyte/tailor/functional/OpeningBraceLineTest.java
+++ b/src/test/java/com/sleekbyte/tailor/functional/OpeningBraceLineTest.java
@@ -20,64 +20,81 @@ public class OpeningBraceLineTest extends RuleTest {
 
     @Override
     protected void addAllExpectedMsgs() {
-        addExpectedMsg(2, 1, Severity.WARNING, Messages.CLASS);
-        addExpectedMsg(7, 5, Severity.WARNING, Messages.INITIALIZER_BODY);
-        addExpectedMsg(14, 5, Severity.WARNING, Messages.FUNCTION);
-        addExpectedMsg(19, 5, Severity.WARNING, Messages.FUNCTION);
-        addExpectedMsg(27, 9, Severity.WARNING, Messages.IF_STATEMENT);
-        addExpectedMsg(32, 9, Severity.WARNING, Messages.IF_STATEMENT);
-        addExpectedMsg(37, 9, Severity.WARNING, Messages.ELSE_CLAUSE);
-        addExpectedMsg(50, 9, Severity.WARNING, Messages.SWITCH_STATEMENT);
-        addExpectedMsg(82, 5, Severity.WARNING, Messages.FUNCTION);
-        addExpectedMsg(87, 9, Severity.WARNING, Messages.FOR_LOOP);
-        addExpectedMsg(92, 9, Severity.WARNING, Messages.FOR_IN_LOOP);
-        addExpectedMsg(97, 9, Severity.WARNING, Messages.WHILE_STATEMENT);
-        addExpectedMsg(102, 9, Severity.WARNING, Messages.REPEAT_WHILE_STATEMENT);
-        addExpectedMsg(113, 4, Severity.WARNING, Messages.CLASS);
-        addExpectedMsg(118, 4, Severity.WARNING, Messages.STRUCT);
-        addExpectedMsg(147, 13, Severity.WARNING, Messages.FOR_LOOP);
-        addExpectedMsg(160, 1, Severity.WARNING, Messages.CLASS);
-        addExpectedMsg(167, 4, Severity.WARNING, Messages.STRUCT);
-        addExpectedMsg(184, 1, Severity.WARNING, Messages.PROTOCOL);
-        addExpectedMsg(199, 1, Severity.WARNING, Messages.PROTOCOL);
-        addExpectedMsg(212, 1, Severity.WARNING, Messages.ENUM);
-        addExpectedMsg(217, 1, Severity.WARNING, Messages.ENUM);
-        addExpectedMsg(223, 1, Severity.WARNING, Messages.ENUM);
-        addExpectedMsg(243, 1, Severity.WARNING, Messages.FUNCTION);
-        addExpectedMsg(262, 1, Severity.WARNING, Messages.CLOSURE);
-        addExpectedMsg(272, 1, Severity.WARNING, Messages.ENUM);
-        addExpectedMsg(281, 1, Severity.WARNING, Messages.CLOSURE);
-        addExpectedMsg(287, 1, Severity.WARNING, Messages.CLOSURE);
-        addExpectedMsg(297, 1, Severity.WARNING, Messages.FUNCTION);
-        addExpectedMsg(302, 1, Severity.WARNING, Messages.ENUM);
-        addExpectedMsg(315, 1, Severity.WARNING, Messages.EXTENSION);
-        addExpectedMsg(320, 1, Severity.WARNING, Messages.EXTENSION);
-        addExpectedMsg(331, 1, Severity.WARNING, Messages.EXTENSION);
-        addExpectedMsg(336, 1, Severity.WARNING, Messages.CLOSURE);
-        addExpectedMsg(341, 1, Severity.WARNING, Messages.CLOSURE);
-        addExpectedMsg(360, 1, Severity.WARNING, Messages.CLOSURE);
-        addExpectedMsg(367, 1, Severity.WARNING, Messages.CLOSURE);
-        addExpectedMsg(394, 10, Severity.WARNING, Messages.SETTER);
-        addExpectedMsg(399, 10, Severity.WARNING, Messages.GETTER);
-        addExpectedMsg(412, 10, Severity.WARNING, Messages.GETTER);
-        addExpectedMsg(421, 9, Severity.WARNING, Messages.GETTER);
-        addExpectedMsg(445, 9, Severity.WARNING, Messages.GETTER);
-        addExpectedMsg(449, 9, Severity.WARNING, Messages.SETTER);
-        addExpectedMsg(460, 9, Severity.WARNING, Messages.SETTER);
-        addExpectedMsg(464, 9, Severity.WARNING, Messages.GETTER);
-        addExpectedMsg(492, 9, Severity.WARNING, Messages.SETTER);
-        addExpectedMsg(503, 5, Severity.WARNING, Messages.SUBSCRIPT);
-        addExpectedMsg(530, 9, Severity.WARNING, Messages.GETTER_SETTER_BLOCK);
-        addExpectedMsg(530, 9, Severity.WARNING, Messages.SUBSCRIPT);
-        addExpectedMsg(546, 13, Severity.WARNING, Messages.WILL_SET_CLAUSE);
-        addExpectedMsg(550, 13, Severity.WARNING, Messages.DID_SET_CLAUSE);
-        addExpectedMsg(561, 13, Severity.WARNING, Messages.WILL_SET_CLAUSE);
-        addExpectedMsg(565, 13, Severity.WARNING, Messages.DID_SET_CLAUSE);
-        addExpectedMsg(589, 13, Severity.WARNING, Messages.WILL_SET_CLAUSE);
-        addExpectedMsg(598, 13, Severity.WARNING, Messages.DID_SET_CLAUSE);
-        addExpectedMsg(608, 13, Severity.WARNING, Messages.WILLSET_DIDSET_BLOCK);
-        addExpectedMsg(644, 13, Severity.WARNING, Messages.WILL_SET_CLAUSE);
-        addExpectedMsg(649, 13, Severity.WARNING, Messages.DID_SET_CLAUSE);
+        int start = 2;
+        addExpectedMsg(start, 1, Severity.WARNING, Messages.CLASS);
+        addExpectedMsg(start + 5, 5, Severity.WARNING, Messages.INITIALIZER_BODY);
+        addExpectedMsg(start + 12, 5, Severity.WARNING, Messages.FUNCTION);
+        addExpectedMsg(start + 17, 5, Severity.WARNING, Messages.FUNCTION);
+
+        start = 27;
+        addExpectedMsg(start, 9, Severity.WARNING, Messages.IF_STATEMENT);
+        addExpectedMsg(start + 5, 9, Severity.WARNING, Messages.IF_STATEMENT);
+        addExpectedMsg(start + 10, 9, Severity.WARNING, Messages.ELSE_CLAUSE);
+        addExpectedMsg(start + 23, 9, Severity.WARNING, Messages.SWITCH_STATEMENT);
+
+        start = 78;
+        addExpectedMsg(start, 5, Severity.WARNING, Messages.FUNCTION);
+        addExpectedMsg(start + 10 - 5, 9, Severity.WARNING, Messages.FOR_IN_LOOP);
+        addExpectedMsg(start + 15 - 5, 9, Severity.WARNING, Messages.WHILE_STATEMENT);
+        addExpectedMsg(start + 20 - 5, 9, Severity.WARNING, Messages.REPEAT_WHILE_STATEMENT);
+        addExpectedMsg(start + 31 - 5, 4, Severity.WARNING, Messages.CLASS);
+        addExpectedMsg(start + 36 - 5, 4, Severity.WARNING, Messages.STRUCT);
+
+        start = 138;
+        addExpectedMsg(start + 13 - 32, 1, Severity.WARNING, Messages.CLASS);
+        addExpectedMsg(start + 20 - 32, 4, Severity.WARNING, Messages.STRUCT);
+        addExpectedMsg(start + 37 - 32, 1, Severity.WARNING, Messages.PROTOCOL);
+        addExpectedMsg(start + 52 - 32, 1, Severity.WARNING, Messages.PROTOCOL);
+
+        start = 171;
+        addExpectedMsg(start, 1, Severity.WARNING, Messages.ENUM);
+        addExpectedMsg(start + 5, 1, Severity.WARNING, Messages.ENUM);
+        addExpectedMsg(start + 11, 1, Severity.WARNING, Messages.ENUM);
+        addExpectedMsg(start + 31, 1, Severity.WARNING, Messages.FUNCTION);
+        addExpectedMsg(start + 50, 1, Severity.WARNING, Messages.CLOSURE);
+
+        start = 231;
+        addExpectedMsg(start, 1, Severity.WARNING, Messages.ENUM);
+        addExpectedMsg(start + 9, 1, Severity.WARNING, Messages.CLOSURE);
+        addExpectedMsg(start + 15, 1, Severity.WARNING, Messages.CLOSURE);
+        addExpectedMsg(start + 25, 1, Severity.WARNING, Messages.FUNCTION);
+        addExpectedMsg(start + 30, 1, Severity.WARNING, Messages.ENUM);
+
+        start = 274;
+        addExpectedMsg(start, 1, Severity.WARNING, Messages.EXTENSION);
+        addExpectedMsg(start + 5, 1, Severity.WARNING, Messages.EXTENSION);
+        addExpectedMsg(start + 16, 1, Severity.WARNING, Messages.EXTENSION);
+        addExpectedMsg(start + 21, 1, Severity.WARNING, Messages.CLOSURE);
+        addExpectedMsg(start + 26, 1, Severity.WARNING, Messages.CLOSURE);
+        addExpectedMsg(start + 45, 1, Severity.WARNING, Messages.CLOSURE);
+        addExpectedMsg(start + 52, 1, Severity.WARNING, Messages.CLOSURE);
+
+        start = 353;
+        addExpectedMsg(start, 10, Severity.WARNING, Messages.SETTER);
+        addExpectedMsg(start + 5, 10, Severity.WARNING, Messages.GETTER);
+        addExpectedMsg(start + 18, 10, Severity.WARNING, Messages.GETTER);
+        addExpectedMsg(start + 27, 9, Severity.WARNING, Messages.GETTER);
+        addExpectedMsg(start + 51, 9, Severity.WARNING, Messages.GETTER);
+
+        start = 408;
+        addExpectedMsg(start, 9, Severity.WARNING, Messages.SETTER);
+        addExpectedMsg(start + 11, 9, Severity.WARNING, Messages.SETTER);
+        addExpectedMsg(start + 15, 9, Severity.WARNING, Messages.GETTER);
+        addExpectedMsg(start + 43, 9, Severity.WARNING, Messages.SETTER);
+        addExpectedMsg(start + 54, 5, Severity.WARNING, Messages.SUBSCRIPT);
+        addExpectedMsg(start + 81, 9, Severity.WARNING, Messages.GETTER_SETTER_BLOCK);
+        addExpectedMsg(start + 81, 9, Severity.WARNING, Messages.SUBSCRIPT);
+
+        start = 505;
+        addExpectedMsg(start, 13, Severity.WARNING, Messages.WILL_SET_CLAUSE);
+        addExpectedMsg(start + 4, 13, Severity.WARNING, Messages.DID_SET_CLAUSE);
+        addExpectedMsg(start + 15, 13, Severity.WARNING, Messages.WILL_SET_CLAUSE);
+        addExpectedMsg(start + 19, 13, Severity.WARNING, Messages.DID_SET_CLAUSE);
+        addExpectedMsg(start + 43, 13, Severity.WARNING, Messages.WILL_SET_CLAUSE);
+        addExpectedMsg(start + 52, 13, Severity.WARNING, Messages.DID_SET_CLAUSE);
+        addExpectedMsg(start + 62, 13, Severity.WARNING, Messages.WILLSET_DIDSET_BLOCK);
+        addExpectedMsg(start + 98, 13, Severity.WARNING, Messages.WILL_SET_CLAUSE);
+        addExpectedMsg(start + 103, 13, Severity.WARNING, Messages.DID_SET_CLAUSE);
     }
 
     private void addExpectedMsg(int line, int column, Severity severity, String msg) {

--- a/src/test/java/com/sleekbyte/tailor/functional/RedundantParenthesesTest.java
+++ b/src/test/java/com/sleekbyte/tailor/functional/RedundantParenthesesTest.java
@@ -17,29 +17,31 @@ public class RedundantParenthesesTest extends RuleTest {
     protected String[] getCommandArgs() {
         return new String[]{ "--only=redundant-parentheses" };
     }
-    
+
     @Override
     protected void addAllExpectedMsgs() {
-        addExpectedMsg(3, 8, Severity.WARNING, Messages.CONDITIONAL_CLAUSE + Messages.ENCLOSED_PARENTHESES);
-        addExpectedMsg(6, 13, Severity.WARNING, Messages.CONDITIONAL_CLAUSE + Messages.ENCLOSED_PARENTHESES);
-        addExpectedMsg(10, 10, Severity.WARNING, Messages.CONDITIONAL_CLAUSE + Messages.ENCLOSED_PARENTHESES);
-        addExpectedMsg(16, 13, Severity.WARNING, Messages.CONDITIONAL_CLAUSE + Messages.ENCLOSED_PARENTHESES);
-        addExpectedMsg(18, 11, Severity.WARNING, Messages.CONDITIONAL_CLAUSE + Messages.ENCLOSED_PARENTHESES);
-        addExpectedMsg(21, 12, Severity.WARNING, Messages.SWITCH_EXPRESSION + Messages.ENCLOSED_PARENTHESES);
-        addExpectedMsg(26, 9, Severity.WARNING, Messages.FOR_LOOP + Messages.ENCLOSED_PARENTHESES);
-        addExpectedMsg(31, 13, Severity.WARNING, Messages.CATCH_CLAUSE + Messages.ENCLOSED_PARENTHESES);
-        addExpectedMsg(35, 11, Severity.WARNING, Messages.THROW_STATEMENT + Messages.ENCLOSED_PARENTHESES);
-        addExpectedMsg(60, 35, Severity.WARNING, Messages.ARRAY_LITERAL + Messages.ENCLOSED_PARENTHESES);
-        addExpectedMsg(60, 45, Severity.WARNING, Messages.ARRAY_LITERAL + Messages.ENCLOSED_PARENTHESES);
-        addExpectedMsg(62, 39, Severity.WARNING, Messages.DICTIONARY_LITERAL + Messages.ENCLOSED_PARENTHESES);
-        addExpectedMsg(62, 48, Severity.WARNING, Messages.DICTIONARY_LITERAL + Messages.ENCLOSED_PARENTHESES);
-        addExpectedMsg(62, 69, Severity.WARNING, Messages.DICTIONARY_LITERAL + Messages.ENCLOSED_PARENTHESES);
-        addExpectedMsg(62, 78, Severity.WARNING, Messages.DICTIONARY_LITERAL + Messages.ENCLOSED_PARENTHESES);
-        addExpectedMsg(66, 18, Severity.WARNING, Messages.INITIALIZER_EXPRESSION + Messages.ENCLOSED_PARENTHESES);
-        addExpectedMsg(67, 21, Severity.WARNING, Messages.INITIALIZER_EXPRESSION + Messages.ENCLOSED_PARENTHESES);
-        addExpectedMsg(68, 13, Severity.WARNING, Messages.INITIALIZER_EXPRESSION + Messages.ENCLOSED_PARENTHESES);
-        addExpectedMsg(78, 10, Severity.WARNING, Messages.EMPTY_PARENTHESES + Messages.REDUNDANT_METHOD_PARENTHESES);
-        addExpectedMsg(92, 15, Severity.WARNING, Messages.EMPTY_PARENTHESES + Messages.REDUNDANT_METHOD_PARENTHESES);
+        int start = 3;
+        addExpectedMsg(start, 8, Severity.WARNING, Messages.CONDITIONAL_CLAUSE + Messages.ENCLOSED_PARENTHESES);
+        addExpectedMsg(start + 3, 13, Severity.WARNING, Messages.CONDITIONAL_CLAUSE + Messages.ENCLOSED_PARENTHESES);
+        addExpectedMsg(start + 7, 10, Severity.WARNING, Messages.CONDITIONAL_CLAUSE + Messages.ENCLOSED_PARENTHESES);
+        addExpectedMsg(start + 13, 13, Severity.WARNING, Messages.CONDITIONAL_CLAUSE + Messages.ENCLOSED_PARENTHESES);
+        addExpectedMsg(start + 15, 11, Severity.WARNING, Messages.CONDITIONAL_CLAUSE + Messages.ENCLOSED_PARENTHESES);
+        addExpectedMsg(start + 18, 12, Severity.WARNING, Messages.SWITCH_EXPRESSION + Messages.ENCLOSED_PARENTHESES);
+        addExpectedMsg(start + 25, 13, Severity.WARNING, Messages.CATCH_CLAUSE + Messages.ENCLOSED_PARENTHESES);
+        addExpectedMsg(start + 29, 11, Severity.WARNING, Messages.THROW_STATEMENT + Messages.ENCLOSED_PARENTHESES);
+
+        start = 57;
+        addExpectedMsg(start, 35, Severity.WARNING, Messages.ARRAY_LITERAL + Messages.ENCLOSED_PARENTHESES);
+        addExpectedMsg(start, 45, Severity.WARNING, Messages.ARRAY_LITERAL + Messages.ENCLOSED_PARENTHESES);
+        addExpectedMsg(start + 2, 39, Severity.WARNING, Messages.DICTIONARY_LITERAL + Messages.ENCLOSED_PARENTHESES);
+        addExpectedMsg(start + 2, 48, Severity.WARNING, Messages.DICTIONARY_LITERAL + Messages.ENCLOSED_PARENTHESES);
+        addExpectedMsg(start + 2, 69, Severity.WARNING, Messages.DICTIONARY_LITERAL + Messages.ENCLOSED_PARENTHESES);
+        addExpectedMsg(start + 2, 78, Severity.WARNING, Messages.DICTIONARY_LITERAL + Messages.ENCLOSED_PARENTHESES);
+        addExpectedMsg(start + 6, 18, Severity.WARNING, Messages.INITIALIZER_EXPRESSION + Messages.ENCLOSED_PARENTHESES);
+        addExpectedMsg(start + 7, 21, Severity.WARNING, Messages.INITIALIZER_EXPRESSION + Messages.ENCLOSED_PARENTHESES);
+        addExpectedMsg(start + 8, 13, Severity.WARNING, Messages.INITIALIZER_EXPRESSION + Messages.ENCLOSED_PARENTHESES);
+        addExpectedMsg(start + 18, 10, Severity.WARNING, Messages.EMPTY_PARENTHESES + Messages.REDUNDANT_METHOD_PARENTHESES);
+        addExpectedMsg(start + 32, 15, Severity.WARNING, Messages.EMPTY_PARENTHESES + Messages.REDUNDANT_METHOD_PARENTHESES);
     }
 
     private void addExpectedMsg(int line, int column, Severity classification, String msg) {

--- a/src/test/java/com/sleekbyte/tailor/functional/RedundantParenthesesTest.java
+++ b/src/test/java/com/sleekbyte/tailor/functional/RedundantParenthesesTest.java
@@ -37,11 +37,16 @@ public class RedundantParenthesesTest extends RuleTest {
         addExpectedMsg(start + 2, 48, Severity.WARNING, Messages.DICTIONARY_LITERAL + Messages.ENCLOSED_PARENTHESES);
         addExpectedMsg(start + 2, 69, Severity.WARNING, Messages.DICTIONARY_LITERAL + Messages.ENCLOSED_PARENTHESES);
         addExpectedMsg(start + 2, 78, Severity.WARNING, Messages.DICTIONARY_LITERAL + Messages.ENCLOSED_PARENTHESES);
-        addExpectedMsg(start + 6, 18, Severity.WARNING, Messages.INITIALIZER_EXPRESSION + Messages.ENCLOSED_PARENTHESES);
-        addExpectedMsg(start + 7, 21, Severity.WARNING, Messages.INITIALIZER_EXPRESSION + Messages.ENCLOSED_PARENTHESES);
-        addExpectedMsg(start + 8, 13, Severity.WARNING, Messages.INITIALIZER_EXPRESSION + Messages.ENCLOSED_PARENTHESES);
-        addExpectedMsg(start + 18, 10, Severity.WARNING, Messages.EMPTY_PARENTHESES + Messages.REDUNDANT_METHOD_PARENTHESES);
-        addExpectedMsg(start + 32, 15, Severity.WARNING, Messages.EMPTY_PARENTHESES + Messages.REDUNDANT_METHOD_PARENTHESES);
+        addExpectedMsg(start + 6, 18, Severity.WARNING,
+            Messages.INITIALIZER_EXPRESSION + Messages.ENCLOSED_PARENTHESES);
+        addExpectedMsg(start + 7, 21, Severity.WARNING,
+            Messages.INITIALIZER_EXPRESSION + Messages.ENCLOSED_PARENTHESES);
+        addExpectedMsg(start + 8, 13, Severity.WARNING,
+            Messages.INITIALIZER_EXPRESSION + Messages.ENCLOSED_PARENTHESES);
+        addExpectedMsg(start + 18, 10, Severity.WARNING,
+            Messages.EMPTY_PARENTHESES + Messages.REDUNDANT_METHOD_PARENTHESES);
+        addExpectedMsg(start + 32, 15, Severity.WARNING,
+            Messages.EMPTY_PARENTHESES + Messages.REDUNDANT_METHOD_PARENTHESES);
     }
 
     private void addExpectedMsg(int line, int column, Severity classification, String msg) {

--- a/src/test/java/com/sleekbyte/tailor/functional/SemicolonTest.java
+++ b/src/test/java/com/sleekbyte/tailor/functional/SemicolonTest.java
@@ -15,33 +15,35 @@ public class SemicolonTest extends RuleTest {
 
     @Override
     protected void addAllExpectedMsgs() {
-        addExpectedMsg(1, 18, Severity.WARNING, Messages.STATEMENTS);
-        addExpectedMsg(6, 15, Severity.WARNING, Messages.STATEMENTS);
-        addExpectedMsg(7, 15, Severity.WARNING, Messages.STATEMENTS);
-        addExpectedMsg(8, 14, Severity.WARNING, Messages.STATEMENTS);
-        addExpectedMsg(9, 14, Severity.WARNING, Messages.STATEMENTS);
-        addExpectedMsg(10, 2, Severity.WARNING, Messages.STATEMENTS);
-        addExpectedMsg(13, 33, Severity.WARNING, Messages.STATEMENTS);
-        addExpectedMsg(14, 16, Severity.WARNING, Messages.STATEMENTS);
-        addExpectedMsg(15, 23, Severity.WARNING, Messages.STATEMENTS);
-        addExpectedMsg(16, 39, Severity.WARNING, Messages.STATEMENTS);
-        addExpectedMsg(17, 2, Severity.WARNING, Messages.STATEMENTS);
-        addExpectedMsg(21, 2, Severity.WARNING, Messages.STATEMENTS);
-        addExpectedMsg(24, 18, Severity.WARNING, Messages.STATEMENTS);
-        addExpectedMsg(29, 10, Severity.WARNING, Messages.STATEMENTS);
-        addExpectedMsg(34, 10, Severity.WARNING, Messages.STATEMENTS);
-        addExpectedMsg(39, 21, Severity.WARNING, Messages.STATEMENTS);
-        addExpectedMsg(40, 6, Severity.WARNING, Messages.STATEMENTS);
-        addExpectedMsg(42, 2, Severity.WARNING, Messages.STATEMENTS);
-        addExpectedMsg(47, 28, Severity.WARNING, Messages.STATEMENTS);
-        addExpectedMsg(48, 14, Severity.WARNING, Messages.STATEMENTS);
-        addExpectedMsg(52, 21, Severity.WARNING, Messages.STATEMENTS);
-        addExpectedMsg(53, 10, Severity.WARNING, Messages.STATEMENTS);
-        addExpectedMsg(56, 65, Severity.WARNING, Messages.STATEMENTS);
-        addExpectedMsg(58, 73, Severity.WARNING, Messages.STATEMENTS);
-        addExpectedMsg(60, 59, Severity.WARNING, Messages.STATEMENTS);
-        addExpectedMsg(62, 6, Severity.WARNING, Messages.STATEMENTS);
-        addExpectedMsg(64, 2, Severity.WARNING, Messages.STATEMENTS);
+        int start = 1;
+        addExpectedMsg(start, 18, Severity.WARNING, Messages.STATEMENTS);
+        addExpectedMsg(start + 5, 15, Severity.WARNING, Messages.STATEMENTS);
+        addExpectedMsg(start + 6, 15, Severity.WARNING, Messages.STATEMENTS);
+        addExpectedMsg(start + 7, 14, Severity.WARNING, Messages.STATEMENTS);
+        addExpectedMsg(start + 8, 14, Severity.WARNING, Messages.STATEMENTS);
+        addExpectedMsg(start + 9, 2, Severity.WARNING, Messages.STATEMENTS);
+        addExpectedMsg(start + 12, 33, Severity.WARNING, Messages.STATEMENTS);
+        addExpectedMsg(start + 13, 16, Severity.WARNING, Messages.STATEMENTS);
+        addExpectedMsg(start + 14, 23, Severity.WARNING, Messages.STATEMENTS);
+        addExpectedMsg(start + 15, 39, Severity.WARNING, Messages.STATEMENTS);
+        addExpectedMsg(start + 16, 2, Severity.WARNING, Messages.STATEMENTS);
+        addExpectedMsg(start + 20, 2, Severity.WARNING, Messages.STATEMENTS);
+
+        start = 24;
+        addExpectedMsg(start, 18, Severity.WARNING, Messages.STATEMENTS);
+        addExpectedMsg(start + 5, 10, Severity.WARNING, Messages.STATEMENTS);
+        addExpectedMsg(start + 15 - 5, 21, Severity.WARNING, Messages.STATEMENTS);
+        addExpectedMsg(start + 16 - 5, 6, Severity.WARNING, Messages.STATEMENTS);
+        addExpectedMsg(start + 18 - 5, 2, Severity.WARNING, Messages.STATEMENTS);
+        addExpectedMsg(start + 23 - 5, 28, Severity.WARNING, Messages.STATEMENTS);
+        addExpectedMsg(start + 24 - 5, 14, Severity.WARNING, Messages.STATEMENTS);
+
+        start = 47;
+        addExpectedMsg(start, 65, Severity.WARNING, Messages.STATEMENTS);
+        addExpectedMsg(start + 2, 73, Severity.WARNING, Messages.STATEMENTS);
+        addExpectedMsg(start + 4, 59, Severity.WARNING, Messages.STATEMENTS);
+        addExpectedMsg(start + 6, 6, Severity.WARNING, Messages.STATEMENTS);
+        addExpectedMsg(start + 8, 2, Severity.WARNING, Messages.STATEMENTS);
     }
 
     private void addExpectedMsg(int line, int column, Severity severity, String msg) {

--- a/src/test/java/com/sleekbyte/tailor/functional/SortedPrinterOutputTest.java
+++ b/src/test/java/com/sleekbyte/tailor/functional/SortedPrinterOutputTest.java
@@ -31,9 +31,8 @@ public class SortedPrinterOutputTest extends RuleTest {
             + Messages.UPPER_CAMEL_CASE);
         addExpectedMsg(Rules.TERMINATING_SEMICOLON, 21, 18, Severity.WARNING, Messages.STATEMENTS + Messages.SEMICOLON);
         addExpectedMsg(Rules.TERMINATING_SEMICOLON, 27, 10, Severity.WARNING, Messages.STATEMENTS + Messages.SEMICOLON);
-        addExpectedMsg(Rules.TERMINATING_SEMICOLON, 31, 10, Severity.WARNING, Messages.STATEMENTS + Messages.SEMICOLON);
-        addExpectedMsg(Rules.TERMINATING_NEWLINE, 34, Severity.WARNING, Messages.FILE + Messages.NEWLINE_TERMINATOR);
-        addExpectedMsg(Rules.TERMINATING_SEMICOLON, 34, 2, Severity.WARNING, Messages.STATEMENTS + Messages.SEMICOLON);
+        addExpectedMsg(Rules.TERMINATING_NEWLINE, 30, Severity.WARNING, Messages.FILE + Messages.NEWLINE_TERMINATOR);
+        addExpectedMsg(Rules.TERMINATING_SEMICOLON, 30, 2, Severity.WARNING, Messages.STATEMENTS + Messages.SEMICOLON);
     }
 
     private void addExpectedMsg(Rules rule, int line, Severity severity, String msg) {

--- a/src/test/java/com/sleekbyte/tailor/functional/yaml/YamlConfigurationTest.java
+++ b/src/test/java/com/sleekbyte/tailor/functional/yaml/YamlConfigurationTest.java
@@ -104,32 +104,22 @@ public final class YamlConfigurationTest {
             Messages.STATEMENTS + Messages.SEMICOLON,
             YAML_TEST_1);
 
-        addExpectedMsg(25, 19,
+        addExpectedMsg(25, 63,
             Rules.TERMINATING_SEMICOLON,
             Messages.STATEMENTS + Messages.SEMICOLON,
             YAML_TEST_1);
 
-        addExpectedMsg(26, 8,
+        addExpectedMsg(27, 71,
             Rules.TERMINATING_SEMICOLON,
             Messages.STATEMENTS + Messages.SEMICOLON,
             YAML_TEST_1);
 
-        addExpectedMsg(29, 63,
+        addExpectedMsg(29, 57,
             Rules.TERMINATING_SEMICOLON,
             Messages.STATEMENTS + Messages.SEMICOLON,
             YAML_TEST_1);
 
-        addExpectedMsg(31, 71,
-            Rules.TERMINATING_SEMICOLON,
-            Messages.STATEMENTS + Messages.SEMICOLON,
-            YAML_TEST_1);
-
-        addExpectedMsg(33, 57,
-            Rules.TERMINATING_SEMICOLON,
-            Messages.STATEMENTS + Messages.SEMICOLON,
-            YAML_TEST_1);
-
-        addExpectedMsg(35, 4,
+        addExpectedMsg(31, 4,
             Rules.TERMINATING_SEMICOLON,
             Messages.STATEMENTS + Messages.SEMICOLON,
             YAML_TEST_1);
@@ -265,32 +255,22 @@ public final class YamlConfigurationTest {
             Messages.STATEMENTS + Messages.SEMICOLON,
             YAML_TEST_1);
 
-        addExpectedMsg(25, 19,
+        addExpectedMsg(25, 63,
             Rules.TERMINATING_SEMICOLON,
             Messages.STATEMENTS + Messages.SEMICOLON,
             YAML_TEST_1);
 
-        addExpectedMsg(26, 8,
+        addExpectedMsg(27, 71,
             Rules.TERMINATING_SEMICOLON,
             Messages.STATEMENTS + Messages.SEMICOLON,
             YAML_TEST_1);
 
-        addExpectedMsg(29, 63,
+        addExpectedMsg(29, 57,
             Rules.TERMINATING_SEMICOLON,
             Messages.STATEMENTS + Messages.SEMICOLON,
             YAML_TEST_1);
 
-        addExpectedMsg(31, 71,
-            Rules.TERMINATING_SEMICOLON,
-            Messages.STATEMENTS + Messages.SEMICOLON,
-            YAML_TEST_1);
-
-        addExpectedMsg(33, 57,
-            Rules.TERMINATING_SEMICOLON,
-            Messages.STATEMENTS + Messages.SEMICOLON,
-            YAML_TEST_1);
-
-        addExpectedMsg(35, 4,
+        addExpectedMsg(31, 4,
             Rules.TERMINATING_SEMICOLON,
             Messages.STATEMENTS + Messages.SEMICOLON,
             YAML_TEST_1);

--- a/src/test/swift/com/sleekbyte/tailor/functional/BraceWhitespaceTest.swift
+++ b/src/test/swift/com/sleekbyte/tailor/functional/BraceWhitespaceTest.swift
@@ -32,10 +32,6 @@ class Rectangle: Shape {
 
     func funWithLoops() {
 
-        for var x = 0; x < lengthArray.count; x+=1  {
-            println(x)
-        }
-
         for breadth in breadthArray  {
             println(breadth)
         }
@@ -52,10 +48,6 @@ class Rectangle: Shape {
     func moreFunWithLoops() {
         let lengthArray = [0,1,2,3,4]
         let breadthArray = [0,1,2,3,4]
-
-        for var x = 0; x < lengthArray.count; x+=1 {
-            println(x)
-        }
 
         for breadth in breadthArray {
             println(breadth)
@@ -86,31 +78,6 @@ class Rectangle: Shape {
    struct Line {
 
          func obscureLoops() {
-            for ; ;  {
-
-            }
-
-            for ;
-                ; {
-
-            }
-
-            var x = 1
-
-            for var x = 1 ; ; {
-
-            }
-
-            for ; ;
-                x  {
-
-            }
-
-            for ; ;
-                x{
-
-            }
-
             for pkg in parms.dependencies where pkg.type == .ModuleMap{
                 println(pkg.name)
             }

--- a/src/test/swift/com/sleekbyte/tailor/functional/ClosingBraceLineTest.swift
+++ b/src/test/swift/com/sleekbyte/tailor/functional/ClosingBraceLineTest.swift
@@ -205,9 +205,6 @@ func printAreaIfStatement() {
         let lengthArray = [0,1,2,3,4]
         let breadthArray = [0,1,2,3,4]
 
-        for var x = 0; x < lengthArray.count; x+=1 {
-            println(x) }
-
         for breadth in breadthArray {
             println(breadth) }
 

--- a/src/test/swift/com/sleekbyte/tailor/functional/CommaWhitespaceTest.swift
+++ b/src/test/swift/com/sleekbyte/tailor/functional/CommaWhitespaceTest.swift
@@ -216,31 +216,6 @@ var (x, y ,z): (Int,Int, Int)
 
 var (x): Int = 2
 
-for (i = 0, j = n - 1; i < n && j >= 0; i++, j--) {
-  println(mat[i][j])
-}
-
-for (i = 0,j = n - 1; i < n && j >= 0; i++, j--) {
-  println(mat[i][j])
-}
-
-for (i = 0,  j = n - 1; i < n && j >= 0; i++ , j--) {
-  println(mat[i][j])
-}
-
-for (i = 0, j = n - 1; i < n && j >= 0; i++  , j--) {
-  println(mat[i][j])
-}
-
-for (var i = 0,
-    j = 300 - 1;
-    i < 29 && j >= 0;
-    i++
-    ,
-    j--) {
-  println(mat[i][j])
-}
-
 shoppingList += ["Chocolate Spread", "Cheese", "Butter"]
 
 shoppingList += ["Chocolate Spread" , "Cheese",  "Butter"]

--- a/src/test/swift/com/sleekbyte/tailor/functional/OpeningBraceLineTest.swift
+++ b/src/test/swift/com/sleekbyte/tailor/functional/OpeningBraceLineTest.swift
@@ -61,10 +61,6 @@ class Rectangle: Shape
         let lengthArray = [0,1,2,3,4]
         let breadthArray = [0,1,2,3,4]
 
-        for var x = 0; x < lengthArray.count; x+=1 {
-            println(x)
-        }
-
         for breadth in breadthArray {
             println(breadth)
         }
@@ -82,11 +78,6 @@ class Rectangle: Shape
     {
         let lengthArray = [0,1,2,3,4]
         let breadthArray = [0,1,2,3,4]
-
-        for var x = 0; x < lengthArray.count; x+=1
-        {
-            println(x)
-        }
 
         for breadth in breadthArray
         {
@@ -117,38 +108,6 @@ class Rectangle: Shape
    struct Square: Shape
    {
         // square struct
-   }
-
-   struct Line {
-
-         func obscureLoops() {
-            for ; ; {
-
-            }
-
-            for ;
-                ; {
-
-            }
-
-            var x = 1
-
-            for var x = 1 ; ; {
-
-            }
-
-            for ; ;
-                x {
-
-            }
-
-            for ; ;
-                x
-            {
-
-            }
-        }
-
    }
 }
 

--- a/src/test/swift/com/sleekbyte/tailor/functional/RedundantParenthesesTest.swift
+++ b/src/test/swift/com/sleekbyte/tailor/functional/RedundantParenthesesTest.swift
@@ -23,9 +23,6 @@ func demo() {
         break
     }
 
-    for (var i = 0; i < 10; i+=1) {
-    }
-
     do {
         try vend(itemNamed: "Candy Bar")
     } catch (VendingMachineError.InvalidSelection) {

--- a/src/test/swift/com/sleekbyte/tailor/functional/SemicolonTest.swift
+++ b/src/test/swift/com/sleekbyte/tailor/functional/SemicolonTest.swift
@@ -28,11 +28,6 @@ struct DemoStruct {
         while true {
         };
 
-        // for loop
-        for ; ; {
-
-        };
-
         // repeat while
         repeat {
 
@@ -48,10 +43,6 @@ class UpperCamelCase {
     let b = 2;
 
     func demo() {
-        for var x = 0; ; {
-            print(x);
-        };
-
         if temperatureInFahrenheit <= 32 {
             println("It's very cold. Consider wearing a scarf.");
         } else if temperatureInFahrenheit >= 86 {

--- a/src/test/swift/com/sleekbyte/tailor/functional/SortedPrinterOutputTest.swift
+++ b/src/test/swift/com/sleekbyte/tailor/functional/SortedPrinterOutputTest.swift
@@ -25,10 +25,6 @@ struct invalidStructName {
         // while loop test
         while true {
         };
-
-        // for loop
-        for ; ; {
-        };
     }
 
 };

--- a/src/test/swift/com/sleekbyte/tailor/functional/yaml/YamlTest1.swift
+++ b/src/test/swift/com/sleekbyte/tailor/functional/yaml/YamlTest1.swift
@@ -21,10 +21,6 @@ class UpperCamelCase: SuperClass {
       let b = 2;
 
   func demo() {
-      for var x = 0; ; {
-          print(x);
-      };
-
       if temperatureInFahrenheit <= 32 {
           println("It's very cold. Consider wearing a scarf.");
       } else if temperatureInFahrenheit >= 86 {

--- a/src/test/swift/com/sleekbyte/tailor/grammar/ClassesAndStructures.swift
+++ b/src/test/swift/com/sleekbyte/tailor/grammar/ClassesAndStructures.swift
@@ -166,6 +166,11 @@ struct AudioChannel {
   internal var suiteHooks: SuiteHooks { return configuration.suiteHooks }
 }
 
+@objc internal final class World {
+  internal var exampleHooks: ExampleHooks {return configuration.exampleHooks }
+  internal var suiteHooks: SuiteHooks { return configuration.suiteHooks }
+}
+
 public final class SessionDelegate: NSObject, NSURLSessionDelegate, NSURLSessionTaskDelegate, NSURLSessionDataDelegate, NSURLSessionDownloadDelegate {
     private var subdelegates: [Int: Request.TaskDelegate] = [:]
 }

--- a/src/test/swift/com/sleekbyte/tailor/grammar/ControlFlow.swift
+++ b/src/test/swift/com/sleekbyte/tailor/grammar/ControlFlow.swift
@@ -16,13 +16,6 @@ let numberOfLegs = ["spider": 8, "ant": 6, "cat": 4]
 for (animalName, legCount) in numberOfLegs {
     print("\(animalName)s have \(legCount) legs")
 }
-for var index = 0; index < 3; ++index {
-    print("index is \(index)")
-}
-var index: Int
-for index = 0; index < 3; ++index {
-    print("index is \(index)")
-}
 
 var square = 0
 var diceRoll = 0
@@ -207,13 +200,6 @@ if #available(iOS 9, OSX 10.10, *) {
     // Use iOS 9 APIs on iOS, and use OS X v10.10 APIs on OS X
 } else {
     // Fall back to earlier iOS and OS X APIs
-}
-
-for var i = 0; i < Int(width); i++, sp = sp.advancedBy(4), dp = dp.advancedBy(4) {
-    let srcAlpha = Int(sp.advancedBy(3).memory) // Blend alpha to dst
-    if srcAlpha == 0xff {
-        memcpy(dp, sp, 4)
-    }
 }
 
 for pkg in parms.dependencies where pkg.type == .ModuleMap {

--- a/src/test/swift/com/sleekbyte/tailor/grammar/Macros.swift
+++ b/src/test/swift/com/sleekbyte/tailor/grammar/Macros.swift
@@ -92,3 +92,11 @@ func test() {
     view.performSelector(#selector(UIView.insertSubview(_:aboveSubview:)),
                          withObject: button, withObject: otherButton)
 }
+
+var validSwiftVersion: Bool = {
+  #if swift(>= 2.2)
+    true
+  #else
+    false
+  #endif
+}

--- a/src/test/swift/com/sleekbyte/tailor/grammar/Protocols.swift
+++ b/src/test/swift/com/sleekbyte/tailor/grammar/Protocols.swift
@@ -191,3 +191,10 @@ extension CollectionType where Generator.Element : TextRepresentable {
         return "(" + ", ".join(map({$0.asText()})) + ")"
     }
 }
+
+protocol Container {
+    associatedtype ItemType
+    mutating func append(item: ItemType)
+    var count: Int { get }
+    subscript(i: Int) -> ItemType { get }
+}

--- a/src/test/swift/com/sleekbyte/tailor/grammar/TypeCasting.swift
+++ b/src/test/swift/com/sleekbyte/tailor/grammar/TypeCasting.swift
@@ -47,3 +47,5 @@ for thing in things {
         print("something else")
     }
 }
+
+let s3 = someValue.dynamicType.init(data: 7)


### PR DESCRIPTION
Changelog:

- Remove C-Style for loops
- Function signatures can only have a single parameter clause (no more curried functions)
- Class declarations are only allowed to have access level modifiers and 'final'
- Protocol associated types now use 'assoicatedtype' keyword
- Tuple pattern element syntax updated
- Initializer expressions can now contain "argument names"
- Language version testing function added to build configurations

Resolves #376.