### PR TITLE
Fix #selector expression

### DIFF
--- a/src/main/antlr/com/sleekbyte/tailor/antlr/Swift.g4
+++ b/src/main/antlr/com/sleekbyte/tailor/antlr/Swift.g4
@@ -628,7 +628,7 @@ implicitMemberExpression : '.' identifier  ;
 // GRAMMAR OF A PARENTHESIZED EXPRESSION
 
 parenthesizedExpression : '(' expressionElementList? ')'  ;
-expressionElementList : expressionElement (',' expressionElement)*  ;
+expressionElementList : expressionElement (','? expressionElement)*  ;
 expressionElement : expression | expressionElementIdentifier ':' expression  ;
 // Swift Language Reference does not have "keyword"
 expressionElementIdentifier: identifier | keyword ;


### PR DESCRIPTION
Repro case:

```swift
#selector(Class.method(_:more:cowbell:))
```

🐶