### PR TITLE
#435: Fix automatic Xcode integration for Ruby 2.3.0+

### DIFF
--- a/src/main/resources/com/sleekbyte/tailor/integration/xcode_integrate.rb
+++ b/src/main/resources/com/sleekbyte/tailor/integration/xcode_integrate.rb
@@ -18,6 +18,7 @@ tailor_gems_dir = find_tailor + 'gems/installed'
 tailor_cache_dir = find_tailor + 'gems/vendor/cache'
 ENV['GEM_HOME'] = tailor_gems_dir.to_s
 ENV['GEM_PATH'] = tailor_gems_dir.to_s
+Gem.use_paths(ENV['GEM_HOME'], ENV['GEM_PATH'])
 cmd = "gem install --local --no-rdoc --no-ri xcodeproj-*.gem"
 Dir.chdir(tailor_cache_dir.to_s){ %%x[#{cmd}] }
 require 'xcodeproj'


### PR DESCRIPTION
Resolves #435.

Verification steps:
Ensure Ruby 2.3.0+ is being used.
```
script/uninstall.sh
./gradlew install
tailor --xcode project.xcodeproj
```