### PR TITLE
#460: Ignoring backticks

### DIFF
--- a/src/main/java/com/sleekbyte/tailor/listeners/ConstantNamingListener.java
+++ b/src/main/java/com/sleekbyte/tailor/listeners/ConstantNamingListener.java
@@ -30,7 +30,7 @@ public class ConstantNamingListener extends SwiftBaseListener {
 
         names.forEach(
             ctx -> {
-                String constantName = ctx.getText();
+                String constantName = CharFormatUtil.unescapeIdentifier(ctx.getText());
                 ParserRuleContext constantDecContext = ConstantDecHelper.getConstantDeclaration(ctx);
                 Location location = ListenerUtil.getContextStartLocation(ctx);
 

--- a/src/main/java/com/sleekbyte/tailor/listeners/KPrefixListener.java
+++ b/src/main/java/com/sleekbyte/tailor/listeners/KPrefixListener.java
@@ -28,7 +28,7 @@ public class KPrefixListener extends SwiftBaseListener {
         List<IdentifierContext> names = DeclarationListener.getConstantNames(topLevelCtx);
         names.forEach(
             ctx -> {
-                String constantName = ctx.getText();
+                String constantName = CharFormatUtil.unescapeIdentifier(ctx.getText());
                 Location location = ListenerUtil.getContextStartLocation(ctx);
                 if (CharFormatUtil.isKPrefixed(constantName)) {
                     printer.warn(Rules.CONSTANT_K_PREFIX, Messages.CONSTANT + Messages.NAME + Messages.K_PREFIXED,

--- a/src/main/java/com/sleekbyte/tailor/listeners/LowerCamelCaseListener.java
+++ b/src/main/java/com/sleekbyte/tailor/listeners/LowerCamelCaseListener.java
@@ -28,28 +28,29 @@ public class LowerCamelCaseListener extends SwiftBaseListener {
     @Override
     public void enterTopLevel(TopLevelContext topLevelCtx) {
         List<IdentifierContext> names = DeclarationListener.getVariableNames(topLevelCtx);
-        names.forEach(ctx -> verifyLowerCamelCase(Messages.VARIABLE + Messages.NAMES, ctx));
+        names.forEach(ctx -> verifyLowerCamelCase(Messages.VARIABLE + Messages.NAMES, ctx, true));
     }
 
     @Override
     public void enterFunctionName(SwiftParser.FunctionNameContext ctx) {
         if (ctx.operator() == null) {
-            verifyLowerCamelCase(Messages.FUNCTION + Messages.NAMES, ctx);
+            verifyLowerCamelCase(Messages.FUNCTION + Messages.NAMES, ctx, false);
         }
     }
 
     @Override
     public void enterRawValueStyleEnumCase(SwiftParser.RawValueStyleEnumCaseContext ctx) {
-        verifyLowerCamelCase(Messages.ENUM_CASE + Messages.NAMES, ctx.enumCaseName());
+        verifyLowerCamelCase(Messages.ENUM_CASE + Messages.NAMES, ctx.enumCaseName(), false);
     }
 
     @Override
     public void enterUnionStyleEnumCase(SwiftParser.UnionStyleEnumCaseContext ctx) {
-        verifyLowerCamelCase(Messages.ENUM_CASE + Messages.NAMES, ctx.enumCaseName());
+        verifyLowerCamelCase(Messages.ENUM_CASE + Messages.NAMES, ctx.enumCaseName(), false);
     }
 
-    private void verifyLowerCamelCase(String constructType, ParserRuleContext ctx) {
-        String constructName = ctx.getText();
+    private void verifyLowerCamelCase(String constructType, ParserRuleContext ctx, Boolean unescapeIdentifier) {
+        String text = unescapeIdentifier ? CharFormatUtil.unescapeIdentifier(ctx.getText()) : ctx.getText();
+        String constructName = CharFormatUtil.unescapeIdentifier(text);
         if (!CharFormatUtil.isLowerCamelCaseOrAcronym(constructName)) {
             Location location = ListenerUtil.getContextStartLocation(ctx);
             this.printer.error(Rules.LOWER_CAMEL_CASE, constructType + Messages.LOWER_CAMEL_CASE, location);

--- a/src/main/java/com/sleekbyte/tailor/utils/CharFormatUtil.java
+++ b/src/main/java/com/sleekbyte/tailor/utils/CharFormatUtil.java
@@ -23,6 +23,14 @@ public final class CharFormatUtil {
     public static boolean isLowerCamelCaseOrAcronym(String word) {
         return startsWithAcronym(word) || isLowerCamelCase(word);
     }
+    
+    public static String unescapeIdentifier(String word) {
+        int length = word.length();
+        if (length >= 2 && word.charAt(0) == '`' && word.charAt(length-1) == '`') {
+            return word.substring(1, length - 2);
+        }
+        return word;
+    }
 
     /**
      * Checks if a name is prefixed with a 'k' or 'K'.

--- a/src/main/java/com/sleekbyte/tailor/utils/CharFormatUtil.java
+++ b/src/main/java/com/sleekbyte/tailor/utils/CharFormatUtil.java
@@ -24,12 +24,18 @@ public final class CharFormatUtil {
         return startsWithAcronym(word) || isLowerCamelCase(word);
     }
     
-    public static String unescapeIdentifier(String word) {
-        int length = word.length();
-        if (length >= 2 && word.charAt(0) == '`' && word.charAt(length-1) == '`') {
-            return word.substring(1, length - 2);
+    /**
+     * Will strip leading and trailing ` character in given string if both present.
+     *
+     * @param identifier value to sanitize
+     * @return sanitized string
+     */
+    public static String unescapeIdentifier(String identifier) {
+        int length = identifier.length();
+        if (length >= 2 && identifier.charAt(0) == '`' && identifier.charAt(length - 1) == '`') {
+            return identifier.substring(1, length - 2);
         }
-        return word;
+        return identifier;
     }
 
     /**

--- a/src/main/java/com/sleekbyte/tailor/utils/CharFormatUtil.java
+++ b/src/main/java/com/sleekbyte/tailor/utils/CharFormatUtil.java
@@ -33,7 +33,7 @@ public final class CharFormatUtil {
     public static String unescapeIdentifier(String identifier) {
         int length = identifier.length();
         if (length >= 2 && identifier.charAt(0) == '`' && identifier.charAt(length - 1) == '`') {
-            return identifier.substring(1, length - 2);
+            return identifier.substring(1, length - 1);
         }
         return identifier;
     }

--- a/src/test/java/com/sleekbyte/tailor/utils/CharFormatUtilTest.java
+++ b/src/test/java/com/sleekbyte/tailor/utils/CharFormatUtilTest.java
@@ -88,4 +88,13 @@ public class CharFormatUtilTest {
         assertFalse(CharFormatUtil.startsWithAcronym("xURLS"));
         assertFalse(CharFormatUtil.startsWithAcronym("shieldPROGRAMMEmarvel"));
     }
+
+    @Test
+    public void testBacktickEscapedIdentifier() {
+        // Backticks are not part of the identifier
+        assertTrue(CharFormatUtil.unescapeIdentifier("`self`").equals("self"));
+        assertFalse(CharFormatUtil.unescapeIdentifier("`self").equals("self"));
+        assertFalse(CharFormatUtil.unescapeIdentifier("self`").equals("self"));
+        assertFalse(CharFormatUtil.unescapeIdentifier("``self`").equals("self"));
+    }
 }


### PR DESCRIPTION
#460 Added util function for removing backticks (`) from variables and constants.

Using this function on `[constant-naming]`, `[lower-camel-case]`, and `[constant-k-prefix]` rules 
