### PR TITLE
#460: Ignore enclosing backticks from identifier analysis.

### DIFF
--- a/src/main/java/com/sleekbyte/tailor/listeners/ConstantNamingListener.java
+++ b/src/main/java/com/sleekbyte/tailor/listeners/ConstantNamingListener.java
@@ -32,11 +32,7 @@ public class ConstantNamingListener extends SwiftBaseListener {
             ctx -> {
                 String constantName = CharFormatUtil.unescapeIdentifier(ctx.getText());
                 ParserRuleContext constantDecContext = ConstantDecHelper.getConstantDeclaration(ctx);
-                Location location = ListenerUtil.getContextStartLocation(ctx);
-                // Ensure that the violation column number reports the character after the opening backtick.
-                if (CharFormatUtil.isEnclosedInBackticks(ctx.getText())) {
-                    location.column += 1;
-                }
+                Location location = ListenerUtil.getIdentifierStartLocation(ctx);
 
                 if (ConstantDecHelper.isGlobal(constantDecContext)
                     || ConstantDecHelper.insideClass(constantDecContext)

--- a/src/main/java/com/sleekbyte/tailor/listeners/ConstantNamingListener.java
+++ b/src/main/java/com/sleekbyte/tailor/listeners/ConstantNamingListener.java
@@ -30,7 +30,7 @@ public class ConstantNamingListener extends SwiftBaseListener {
 
         names.forEach(
             ctx -> {
-                String constantName = ctx.getText();
+                String constantName = CharFormatUtil.unescapeIdentifier(ctx.getText());
                 ParserRuleContext constantDecContext = ConstantDecHelper.getConstantDeclaration(ctx);
                 Location location = ListenerUtil.getContextStartLocation(ctx);
 

--- a/src/main/java/com/sleekbyte/tailor/listeners/ConstantNamingListener.java
+++ b/src/main/java/com/sleekbyte/tailor/listeners/ConstantNamingListener.java
@@ -33,6 +33,10 @@ public class ConstantNamingListener extends SwiftBaseListener {
                 String constantName = CharFormatUtil.unescapeIdentifier(ctx.getText());
                 ParserRuleContext constantDecContext = ConstantDecHelper.getConstantDeclaration(ctx);
                 Location location = ListenerUtil.getContextStartLocation(ctx);
+                // Ensure that the violation column number reports the character after the opening backtick.
+                if (CharFormatUtil.isEnclosedInBackticks(ctx.getText())) {
+                    location.column += 1;
+                }
 
                 if (ConstantDecHelper.isGlobal(constantDecContext)
                     || ConstantDecHelper.insideClass(constantDecContext)

--- a/src/main/java/com/sleekbyte/tailor/listeners/KPrefixListener.java
+++ b/src/main/java/com/sleekbyte/tailor/listeners/KPrefixListener.java
@@ -29,11 +29,7 @@ public class KPrefixListener extends SwiftBaseListener {
         names.forEach(
             ctx -> {
                 String constantName = CharFormatUtil.unescapeIdentifier(ctx.getText());
-                Location location = ListenerUtil.getContextStartLocation(ctx);
-                // Ensure that the violation column number reports the character after the opening backtick.
-                if (CharFormatUtil.isEnclosedInBackticks(ctx.getText())) {
-                    location.column += 1;
-                }
+                Location location = ListenerUtil.getIdentifierStartLocation(ctx);
                 if (CharFormatUtil.isKPrefixed(constantName)) {
                     printer.warn(Rules.CONSTANT_K_PREFIX, Messages.CONSTANT + Messages.NAME + Messages.K_PREFIXED,
                         location);

--- a/src/main/java/com/sleekbyte/tailor/listeners/KPrefixListener.java
+++ b/src/main/java/com/sleekbyte/tailor/listeners/KPrefixListener.java
@@ -30,6 +30,10 @@ public class KPrefixListener extends SwiftBaseListener {
             ctx -> {
                 String constantName = CharFormatUtil.unescapeIdentifier(ctx.getText());
                 Location location = ListenerUtil.getContextStartLocation(ctx);
+                // Ensure that the violation column number reports the character after the opening backtick.
+                if (CharFormatUtil.isEnclosedInBackticks(ctx.getText())) {
+                    location.column += 1;
+                }
                 if (CharFormatUtil.isKPrefixed(constantName)) {
                     printer.warn(Rules.CONSTANT_K_PREFIX, Messages.CONSTANT + Messages.NAME + Messages.K_PREFIXED,
                         location);

--- a/src/main/java/com/sleekbyte/tailor/listeners/KPrefixListener.java
+++ b/src/main/java/com/sleekbyte/tailor/listeners/KPrefixListener.java
@@ -28,7 +28,7 @@ public class KPrefixListener extends SwiftBaseListener {
         List<IdentifierContext> names = DeclarationListener.getConstantNames(topLevelCtx);
         names.forEach(
             ctx -> {
-                String constantName = ctx.getText();
+                String constantName = CharFormatUtil.unescapeIdentifier(ctx.getText());
                 Location location = ListenerUtil.getContextStartLocation(ctx);
                 if (CharFormatUtil.isKPrefixed(constantName)) {
                     printer.warn(Rules.CONSTANT_K_PREFIX, Messages.CONSTANT + Messages.NAME + Messages.K_PREFIXED,

--- a/src/main/java/com/sleekbyte/tailor/listeners/LowerCamelCaseListener.java
+++ b/src/main/java/com/sleekbyte/tailor/listeners/LowerCamelCaseListener.java
@@ -28,7 +28,7 @@ public class LowerCamelCaseListener extends SwiftBaseListener {
     @Override
     public void enterTopLevel(TopLevelContext topLevelCtx) {
         List<IdentifierContext> names = DeclarationListener.getVariableNames(topLevelCtx);
-        names.forEach(ctx -> verifyLowerCamelCase(Messages.VARIABLE + Messages.NAMES, ctx));
+        names.forEach(ctx -> verifyLowerCamelCase(Messages.VARIABLE + Messages.NAMES, ctx, true));
     }
 
     @Override
@@ -49,7 +49,12 @@ public class LowerCamelCaseListener extends SwiftBaseListener {
     }
 
     private void verifyLowerCamelCase(String constructType, ParserRuleContext ctx) {
-        String constructName = ctx.getText();
+        verifyLowerCamelCase(constructType, ctx, false);
+    }
+
+    private void verifyLowerCamelCase(String constructType, ParserRuleContext ctx, Boolean unescapeIdentifier) {
+        String text = unescapeIdentifier ? CharFormatUtil.unescapeIdentifier(ctx.getText()) : ctx.getText();
+        String constructName = CharFormatUtil.unescapeIdentifier(text);
         if (!CharFormatUtil.isLowerCamelCaseOrAcronym(constructName)) {
             Location location = ListenerUtil.getContextStartLocation(ctx);
             this.printer.error(Rules.LOWER_CAMEL_CASE, constructType + Messages.LOWER_CAMEL_CASE, location);

--- a/src/main/java/com/sleekbyte/tailor/listeners/LowerCamelCaseListener.java
+++ b/src/main/java/com/sleekbyte/tailor/listeners/LowerCamelCaseListener.java
@@ -28,7 +28,7 @@ public class LowerCamelCaseListener extends SwiftBaseListener {
     @Override
     public void enterTopLevel(TopLevelContext topLevelCtx) {
         List<IdentifierContext> names = DeclarationListener.getVariableNames(topLevelCtx);
-        names.forEach(ctx -> verifyLowerCamelCase(Messages.VARIABLE + Messages.NAMES, ctx, true));
+        names.forEach(ctx -> verifyLowerCamelCase(Messages.VARIABLE + Messages.NAMES, ctx));
     }
 
     @Override
@@ -49,16 +49,11 @@ public class LowerCamelCaseListener extends SwiftBaseListener {
     }
 
     private void verifyLowerCamelCase(String constructType, ParserRuleContext ctx) {
-        verifyLowerCamelCase(constructType, ctx, false);
-    }
-
-    private void verifyLowerCamelCase(String constructType, ParserRuleContext ctx, Boolean unescapeIdentifier) {
-        String text = unescapeIdentifier ? CharFormatUtil.unescapeIdentifier(ctx.getText()) : ctx.getText();
-        String constructName = CharFormatUtil.unescapeIdentifier(text);
+        String constructName = CharFormatUtil.unescapeIdentifier(ctx.getText());
         if (!CharFormatUtil.isLowerCamelCaseOrAcronym(constructName)) {
             Location location = ListenerUtil.getContextStartLocation(ctx);
             // Ensure that the violation column number reports the character after the opening backtick.
-            if (unescapeIdentifier && CharFormatUtil.isEnclosedInBackticks(ctx.getText())) {
+            if (CharFormatUtil.isEnclosedInBackticks(ctx.getText())) {
                 location.column += 1;
             }
             this.printer.error(Rules.LOWER_CAMEL_CASE, constructType + Messages.LOWER_CAMEL_CASE, location);

--- a/src/main/java/com/sleekbyte/tailor/listeners/LowerCamelCaseListener.java
+++ b/src/main/java/com/sleekbyte/tailor/listeners/LowerCamelCaseListener.java
@@ -57,6 +57,10 @@ public class LowerCamelCaseListener extends SwiftBaseListener {
         String constructName = CharFormatUtil.unescapeIdentifier(text);
         if (!CharFormatUtil.isLowerCamelCaseOrAcronym(constructName)) {
             Location location = ListenerUtil.getContextStartLocation(ctx);
+            // Ensure that the violation column number reports the character after the opening backtick.
+            if (unescapeIdentifier && CharFormatUtil.isEnclosedInBackticks(ctx.getText())) {
+                location.column += 1;
+            }
             this.printer.error(Rules.LOWER_CAMEL_CASE, constructType + Messages.LOWER_CAMEL_CASE, location);
         }
     }

--- a/src/main/java/com/sleekbyte/tailor/listeners/LowerCamelCaseListener.java
+++ b/src/main/java/com/sleekbyte/tailor/listeners/LowerCamelCaseListener.java
@@ -51,11 +51,7 @@ public class LowerCamelCaseListener extends SwiftBaseListener {
     private void verifyLowerCamelCase(String constructType, ParserRuleContext ctx) {
         String constructName = CharFormatUtil.unescapeIdentifier(ctx.getText());
         if (!CharFormatUtil.isLowerCamelCaseOrAcronym(constructName)) {
-            Location location = ListenerUtil.getContextStartLocation(ctx);
-            // Ensure that the violation column number reports the character after the opening backtick.
-            if (CharFormatUtil.isEnclosedInBackticks(ctx.getText())) {
-                location.column += 1;
-            }
+            Location location = ListenerUtil.getIdentifierStartLocation(ctx);
             this.printer.error(Rules.LOWER_CAMEL_CASE, constructType + Messages.LOWER_CAMEL_CASE, location);
         }
     }

--- a/src/main/java/com/sleekbyte/tailor/utils/CharFormatUtil.java
+++ b/src/main/java/com/sleekbyte/tailor/utils/CharFormatUtil.java
@@ -24,6 +24,11 @@ public final class CharFormatUtil {
         return startsWithAcronym(word) || isLowerCamelCase(word);
     }
 
+    public static boolean isEnclosedInBackticks(String identifier) {
+        int length = identifier.length();
+        return length >= 2 && identifier.charAt(0) == '`' && identifier.charAt(length - 1) == '`';
+    }
+
     /**
      * Will strip leading and trailing ` character in given string if both present.
      *
@@ -32,7 +37,7 @@ public final class CharFormatUtil {
      */
     public static String unescapeIdentifier(String identifier) {
         int length = identifier.length();
-        if (length >= 2 && identifier.charAt(0) == '`' && identifier.charAt(length - 1) == '`') {
+        if (isEnclosedInBackticks(identifier)) {
             return identifier.substring(1, length - 1);
         }
         return identifier;

--- a/src/main/java/com/sleekbyte/tailor/utils/CharFormatUtil.java
+++ b/src/main/java/com/sleekbyte/tailor/utils/CharFormatUtil.java
@@ -25,6 +25,20 @@ public final class CharFormatUtil {
     }
 
     /**
+     * Will strip leading and trailing ` character in given string if both present.
+     *
+     * @param identifier value to sanitize
+     * @return sanitized string
+     */
+    public static String unescapeIdentifier(String identifier) {
+        int length = identifier.length();
+        if (length >= 2 && identifier.charAt(0) == '`' && identifier.charAt(length - 1) == '`') {
+            return identifier.substring(1, length - 1);
+        }
+        return identifier;
+    }
+
+    /**
      * Checks if a name is prefixed with a 'k' or 'K'.
      *
      * @param name the name of an identifier

--- a/src/main/java/com/sleekbyte/tailor/utils/ListenerUtil.java
+++ b/src/main/java/com/sleekbyte/tailor/utils/ListenerUtil.java
@@ -32,6 +32,20 @@ public final class ListenerUtil {
         return new Location(ctx.getStop().getLine(), ctx.getStop().getCharPositionInLine() + 1);
     }
 
+    /**
+     * Gets the start location of the context string.
+     * @param ctx the context
+     * @return the start location of the provided context's string
+     */
+    public static Location getIdentifierStartLocation(ParserRuleContext ctx) {
+        Location location = getContextStartLocation(ctx);
+        // Ensure that the violation column number reports the character after the opening backtick.
+        if (CharFormatUtil.isEnclosedInBackticks(ctx.getText())) {
+            location.column += 1;
+        }
+        return location;
+    }
+
     public static Location getLocationOfChildToken(ParserRuleContext ctx, int childNumber) {
         Token token = ((TerminalNodeImpl) ctx.getChild(childNumber)).getSymbol();
         return ListenerUtil.getTokenLocation(token);

--- a/src/main/java/com/sleekbyte/tailor/utils/Pair.java
+++ b/src/main/java/com/sleekbyte/tailor/utils/Pair.java
@@ -4,8 +4,8 @@ package com.sleekbyte.tailor.utils;
  * Couples together a pair of values, which may be of different types (L and R).
  * The individual values can be accessed via its public getter functions getFirst() and getSecond().
  *
- * @param <L> Type of member first.
- * @param <R> Type of member second.
+ * @param <L> Type of member first
+ * @param <R> Type of member second
  */
 public final class Pair<L, R> {
     private final L first;

--- a/src/test/java/com/sleekbyte/tailor/functional/ConstantNamingTest.java
+++ b/src/test/java/com/sleekbyte/tailor/functional/ConstantNamingTest.java
@@ -62,6 +62,7 @@ public class ConstantNamingTest extends RuleTest {
             + Messages.K_PREFIXED);
         addExpectedMsg(Rules.CONSTANT_K_PREFIX, 134, 20, Severity.WARNING, Messages.CONSTANT + Messages.NAME
             + Messages.K_PREFIXED);
+        addExpectedMsg(Rules.CONSTANT_NAMING, 152, 14, Severity.WARNING, Messages.CONSTANT + Messages.LOWER_CAMEL_CASE);
     }
 
     @Override

--- a/src/test/java/com/sleekbyte/tailor/functional/LowerCamelCaseTest.java
+++ b/src/test/java/com/sleekbyte/tailor/functional/LowerCamelCaseTest.java
@@ -44,6 +44,7 @@ public class LowerCamelCaseTest extends RuleTest {
         addExpectedMsg(176, 10, Severity.WARNING, Messages.ENUM_CASE + Messages.NAMES + Messages.LOWER_CAMEL_CASE);
         addExpectedMsg(177, 10, Severity.WARNING, Messages.ENUM_CASE + Messages.NAMES + Messages.LOWER_CAMEL_CASE);
         addExpectedMsg(190, 10, Severity.WARNING, Messages.ENUM_CASE + Messages.NAMES + Messages.LOWER_CAMEL_CASE);
+        addExpectedMsg(200, 10, Severity.WARNING, Messages.VARIABLE + Messages.NAMES + Messages.LOWER_CAMEL_CASE);
     }
 
     private void addExpectedMsg(int line, int column, Severity severity, String msg) {

--- a/src/test/java/com/sleekbyte/tailor/utils/CharFormatUtilTest.java
+++ b/src/test/java/com/sleekbyte/tailor/utils/CharFormatUtilTest.java
@@ -1,5 +1,6 @@
 package com.sleekbyte.tailor.utils;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -94,10 +95,11 @@ public class CharFormatUtilTest {
         // Backtick(s) are not part of the identifier
         assertTrue(CharFormatUtil.unescapeIdentifier("``").isEmpty());
         assertTrue(CharFormatUtil.unescapeIdentifier("").isEmpty());
-        assertTrue(CharFormatUtil.unescapeIdentifier("`s`").equals("s"));
-        assertTrue(CharFormatUtil.unescapeIdentifier("`self`").equals("self"));
-        assertFalse(CharFormatUtil.unescapeIdentifier("`self").equals("self"));
-        assertFalse(CharFormatUtil.unescapeIdentifier("self`").equals("self"));
-        assertFalse(CharFormatUtil.unescapeIdentifier("``self`").equals("self"));
+        assertEquals("self", CharFormatUtil.unescapeIdentifier("`self`"));
+        assertEquals("s",CharFormatUtil.unescapeIdentifier("`s`"));
+        assertEquals("self",CharFormatUtil.unescapeIdentifier("`self`"));
+        assertEquals("`self", CharFormatUtil.unescapeIdentifier("`self"));
+        assertEquals("self`", CharFormatUtil.unescapeIdentifier("self`"));
+        assertEquals("`self", CharFormatUtil.unescapeIdentifier("``self`"));
     }
 }

--- a/src/test/java/com/sleekbyte/tailor/utils/CharFormatUtilTest.java
+++ b/src/test/java/com/sleekbyte/tailor/utils/CharFormatUtilTest.java
@@ -88,4 +88,16 @@ public class CharFormatUtilTest {
         assertFalse(CharFormatUtil.startsWithAcronym("xURLS"));
         assertFalse(CharFormatUtil.startsWithAcronym("shieldPROGRAMMEmarvel"));
     }
+
+    @Test
+    public void testBacktickEscapedIdentifier() {
+        // Backtick(s) are not part of the identifier
+        assertTrue(CharFormatUtil.unescapeIdentifier("``").isEmpty());
+        assertTrue(CharFormatUtil.unescapeIdentifier("").isEmpty());
+        assertTrue(CharFormatUtil.unescapeIdentifier("`s`").equals("s"));
+        assertTrue(CharFormatUtil.unescapeIdentifier("`self`").equals("self"));
+        assertFalse(CharFormatUtil.unescapeIdentifier("`self").equals("self"));
+        assertFalse(CharFormatUtil.unescapeIdentifier("self`").equals("self"));
+        assertFalse(CharFormatUtil.unescapeIdentifier("``self`").equals("self"));
+    }
 }

--- a/src/test/swift/com/sleekbyte/tailor/functional/ConstantNamingTest.swift
+++ b/src/test/swift/com/sleekbyte/tailor/functional/ConstantNamingTest.swift
@@ -147,4 +147,8 @@ private struct Scaling {
 
     let `open` = true
     var `close` = false
+
+    func demo() {
+        let `Open` = true
+    }
 }

--- a/src/test/swift/com/sleekbyte/tailor/functional/ConstantNamingTest.swift
+++ b/src/test/swift/com/sleekbyte/tailor/functional/ConstantNamingTest.swift
@@ -145,4 +145,6 @@ private struct Scaling {
     init?(URL url: NSURL, statusCode statusCode: Int, HTTPVersion HTTPVersion: String?, headerFields headerFields: [String: String]?) {
     }
 
+    let `open` = true
+    var `close` = false
 }

--- a/src/test/swift/com/sleekbyte/tailor/functional/LowerCamelCaseTest.swift
+++ b/src/test/swift/com/sleekbyte/tailor/functional/LowerCamelCaseTest.swift
@@ -195,3 +195,8 @@ enum SomeEnum: Int {
         }
     }
 }
+
+func demo() {
+    let `open` = true
+    var `close` = false
+}

--- a/src/test/swift/com/sleekbyte/tailor/functional/LowerCamelCaseTest.swift
+++ b/src/test/swift/com/sleekbyte/tailor/functional/LowerCamelCaseTest.swift
@@ -197,6 +197,7 @@ enum SomeEnum: Int {
 }
 
 func demo() {
-    let `open` = true
+    var `Open` = true
     var `close` = false
+    let `open` = true
 }

--- a/src/test/swift/com/sleekbyte/tailor/functional/LowerCamelCaseTest.swift
+++ b/src/test/swift/com/sleekbyte/tailor/functional/LowerCamelCaseTest.swift
@@ -201,3 +201,10 @@ func demo() {
     var `close` = false
     let `open` = true
 }
+
+func `func`() {
+}
+
+enum Test {
+    case `case`, `class`, notReserved
+}


### PR DESCRIPTION
Based on the work done in #461 by @kober32 last year.

>Added util function for removing backticks (`) from variables and constants.
Using this function on `[constant-naming]`, `[lower-camel-case]`, and `[constant-k-prefix]` rules 

Fixes #460.