### PR TITLE
Add swift4 keyPath support

### DIFF
--- a/src/main/antlr/com/sleekbyte/tailor/antlr/Swift.g4
+++ b/src/main/antlr/com/sleekbyte/tailor/antlr/Swift.g4
@@ -670,7 +670,10 @@ selectorExpression
 
 // GRAMMAR OF A KEY PATH EXPRESSION
 
-keyPathExpression: '#keyPath' '(' expression ')' ;
+keyPathExpression
+ : '#keyPath' '(' expression ')' 
+ | '\\' expression
+;
 
 // GRAMMAR OF A POSTFIX EXPRESSION
 

--- a/src/test/swift/com/sleekbyte/tailor/grammar/Macros.swift
+++ b/src/test/swift/com/sleekbyte/tailor/grammar/Macros.swift
@@ -109,6 +109,9 @@ var validSwiftVersion: Bool = {
     func keyPathTest() -> String {
         return #keyPath(someProperty)
     }
+    func keyPathTestForSwift4() -> KeyPath<SomeClass, Int> {
+        return \SomeClass.someProperty
+    }
 }
 
 let c = SomeClass(someProperty: 12)


### PR DESCRIPTION
\ can now be used to specify keyPaths, so I added one usage in Macros.swift and patched the grammar file

See :  https://github.com/apple/swift-evolution/blob/master/proposals/0161-key-paths.md and https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift_Programming_Language/zzSummaryOfTheGrammar.html